### PR TITLE
Changing 637.5 to 637a for Rails compatibility

### DIFF
--- a/catalogo.tei.xml
+++ b/catalogo.tei.xml
@@ -35,7 +35,7 @@
           <correction>
             <p>There is no label for the item between 637 and 638.  To
             support indexing in the DCL application, we have assigned
-            it the number 637.5, pending an authoratative
+            it the number 637a, pending an authoratative
             solution.</p>
           </correction>
           <correction>
@@ -9681,7 +9681,7 @@
 	nella seconda si riconosce il passaggio dall’architettura egiziana alla greca.</note>
 	              </item>
                <!--Added title without number-->   
-	              <item xml:id="c1d1e18450" n="637.5">
+	              <item xml:id="c1d1e18450" n="637a">
                   <bibl> Le ROUX G. B., Vedi Boissard Robert, nouveaux lambris de Galerie etc.</bibl> 
 	              </item>
 	              <item xml:id="c1d1e18456" n="638" corresp="cico:6s0">


### PR DESCRIPTION
Rails parses "637.5" as `id: 637, format: 5` — changing format of the inter-item numbering to avoid this.