### PR TITLE
Catalogo entries w/o Getty record

### DIFF
--- a/bin/catalogo_items_not_in_getty.xml
+++ b/bin/catalogo_items_not_in_getty.xml
@@ -1,0 +1,5555 @@
+<tei:list xmlns="http://www.tei-c.org/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0">
+   <item xml:id="c1d1e666" n="10" corresp="dcl:rbz">
+      <label>10.</label>
+      <bibl>
+         <author>BIANCHI Isidoro</author>, <title>Delle scienze e delle arti. Dissertazione
+            apologetica,</title>
+         <pubPlace>Palermo</pubPlace>
+         <date>1771,</date>
+         <extent> in 8.</extent>
+      </bibl>
+   </item>
+   <item xml:id="c1d1e845" n="16" corresp="dcl:xbp">
+      <label>16.</label>
+      <bibl>
+         <author>BUCHNERO (Andr. Eliæ)</author>, <title>De praeservandis artificum et opificum
+            morbis. Dissertatio inauguralis medica,</title>
+         <pubPlace>Halæ Magdeb.</pubPlace>
+         <date>1745,</date>
+         <extent>M. 45.</extent>
+      </bibl>
+   </item>
+   <item xml:id="c1d1e928" n="19">
+      <label>19.</label>
+      <bibl>
+         <title>COLLEZIONE di dissertazioni di diversi autori in materia d’arti e di
+            antichità,</title>
+         <publisher> pubblicate da Antonio Groppo</publisher>
+         <pubPlace>in Venezia,</pubPlace>
+         <date> dal 1748 </date>
+         <extent>in poi in 4.</extent>
+      </bibl>
+   </item>
+   <item xml:id="c1d1e1647" n="44" corresp="dcl:pbx">
+      <label>44.</label>
+      <bibl>
+         <author>MORENI Domenico</author>, <title> Memoria intorno al risorgimento delle belle arti
+            in Toscana,</title>
+         <pubPlace>Firenze</pubPlace>
+         <date> 1812.</date>
+      </bibl>
+   </item>
+   <item xml:id="c1d1e1744" n="48">
+      <label>48.</label>
+      <bibl>
+         <author>QUATRÈMERE de Quinci</author>, <title> Considerations morales sur la destination
+            des ouvrages de l’art, ou de l’influence de leur emploi sur le genie et le goût,</title>
+         <pubPlace>Paris</pubPlace>
+         <date> 1815,</date>
+         <extent>in 8, M. 102.</extent>
+      </bibl>
+      <note>Opera suscettibile di maggior estensione, piena di belle idee e fino criterio</note>
+   </item>
+   <item xml:id="c1d1e1995" n="57">
+      <label>57.</label>
+      <bibl>
+         <title>TRATTATO intorno alla storia naturale, al quale si è aggiunto un altro sopra le
+            arti, tradotti dal francese,</title>
+         <pubPlace>Venezia</pubPlace>
+         <date>1739,</date>
+         <extent> 8, M. 55.</extent>
+      </bibl>
+      <note>Singolare e disordinata è la disposizione delle materie raccolte in questo opuscolo
+         piuttosto conforme a una raccolta d’aneddoti che ad un trattato.</note>
+   </item>
+   <item xml:id="c1d1e2218" n="65" corresp="dcl:9zn">
+      <label>65.</label>
+      <bibl>
+         <author>ZANI D. Pietro</author>, <title>Enciclopedia Metodica, Critico-ragionata delle
+            belle arti,</title>
+         <extent>volumi 6,</extent>
+         <pubPlace>Parma</pubPlace>
+         <date>1820.</date>
+      </bibl>
+      <note>Finora non sono pubblicati che questi, e l’opera trovasi nel suo principio. Conceda il
+         cielo vita all’attempato autore per vedere, se non il termine, almeno non notabile
+         avanzamento in questo mare di utilissime cognizioni, alle quali avranno sempre ricorso
+         tutti gli amatori di questi studi.</note>
+   </item>
+   <item xml:id="c1d1e3857" n="123" corresp="dcl:w7x">
+      <label>123.</label>
+      <bibl>
+         <title>ESSAI sur la peinture en mosaique. Par M. avec une dissertation sur la pierre
+            speculaire des anciens, </title>
+         <pubPlace>Paris</pubPlace>
+         <date>1768,</date>
+         <extent> in 8.</extent>
+      </bibl>
+   </item>
+   <item xml:id="c1d1e4124" n="133" corresp="dcl:4cn">
+      <label>133.</label>
+      <bibl>
+         <author>GEORGII Joannis</author>, <title> Disputatio iuridica de eo quod iustum est circa
+            picturam,</title>
+         <pubPlace>Aldorf.</pubPlace>
+         <date>1716,</date>
+         <extent>in 4, M. 15.</extent>
+      </bibl>
+      <note>Questa è una dissertazione in materia legale, che riguarda i diritti degli offesi da
+         pitture ingiuriose.</note>
+   </item>
+   <item xml:id="c1d1e4151" n="134" corresp="dcl:669">
+      <label>134.</label>
+      <bibl>
+         <author>GILIO Giovanni Andrea</author> da Fabriano, <title>Due Dialoghi, nel primo de’
+            quali si ragiona delle parti morali e civili de’ letterati e cortigiani e dell’utile che
+            i principi cavano da’ letterati; nel secondo si tratta degli errori de’ pittori circa le
+            storie,</title>
+         <pubPlace>in Camerino,</pubPlace>
+         <publisher>presso Antonio Gioioso,</publisher>
+         <date>1564,</date>
+         <extent> in 4.</extent>
+      </bibl>
+      <note>In questo libro è riunito un magazzino d’erudizioni con poco ordine per mettere in
+         evidenza l’autore, senza che le arti ne abbiano tratto profitto. L’edizione è
+         accurata.</note>
+   </item>
+   <item xml:id="c1d1e4928" n="161">
+      <label>161.</label>
+      <bibl>
+         <author>LOMAZZO Giovanni Paolo</author> milanese pittore, <title>La stessa opera col primo
+            frontispizio del 1584 e il foglietto in fine da collocarsi a carte 328 stampato.</title>
+      </bibl>
+      <note>Esemplare rarissimo e prezioso che stava nelle biblioteche Bianconi, poi Bossi. Non
+         conosciamo simile esemplare che nella Smithiana. Legato in vit. e di bellissima
+         conservazione.</note>
+   </item>
+   <item xml:id="c1d1e5081" n="167">
+      <label>167.</label>
+      <bibl>
+         <title>MEMORIALE dato da’ pittori del 1685 alli senatori di Bologna per essere liberati
+            dalla così detta obbedienza dell’arte ed essere separati da’ meccanici pignattari,
+            scutellari, coramari, ventolari, indoratori, coi quali erano stati posti nei secoli, in
+            cui la pittura era trattata miserabilmente e confinata al consorzio delle arti vili
+            suddette.</title>
+      </bibl>
+      <note>Memoriale rarissimo ad aversi e che serve alla storia dell’arte del disegno, massime per
+         la bolognese. – Il Malvasia parla in più luoghi del desiderio che avevano i pittori
+         riguardo alla detta liberazione. Questi non sono che due fogli di stampa. Bologna, presso
+         Giacomo Monti, 1685, in fog. V in Wredman Panoplia.</note>
+      <fw type="foot"/>
+      <pb type="memofonte"/>
+      <fw type="head"/>
+   </item>
+   <item xml:id="c1d1e5807" n="189">
+      <label>189.</label>
+      <bibl>
+         <author>POSSEVINI Antonii</author>, <title>Bibliotheca selecta de ratione
+            studiorum,</title>
+         <pubPlace>Venetiis</pubPlace>
+         <date>1603</date>,<extent> in fol., vol. 2.</extent>
+      </bibl>
+      <note>Trovasi in quest’opera il suddetto trattato.</note>
+   </item>
+   <item xml:id="c1d1e7157" n="237" corresp="dcl:vv9 dcl:1ps">
+      <label>237.</label>
+      <bibl>
+         <author>Da VINCI Lionardo</author>, <title>Trattato della pittura tratto da un codice della
+            Biblioteca Vaticana</title> e pubblicato da <publisher>Guglielmo Manzi</publisher>,
+            <pubPlace>Roma</pubPlace>
+         <date>1817</date>,<extent> in 4;</extent> unitovi un atlante di stampe.</bibl>
+      <note>Questo codice esisteva nella libreria dei duchi d’Urbino, e per la morte di Francesco M.
+         della Rovere passò cogli stati al dominio pontificio. Le figure furono lumeggiate dal
+         codice senza la biasimevole, che vedesi nell’edizione di Parigi per opera del pittore
+         Errard. Può questo ritenersi per l’edizione la più ampia e corretta a seconda dell’antico
+         originale. Questo diligente editore estese anche la vita di Leonardo in 28 pagine e pose al
+         fine alcune note al trattato estese dal sig. Giovanni Gherardo de’ Rossi; e prima delle
+         tavole è il ritratto di Leonardo.</note>
+   </item>
+   <item xml:id="c1d1e7400" n="246" corresp="dcl:45t">
+      <label>246.</label>
+      <bibl>
+         <author>ZUCCARI</author>, <title>Il passaggio per l’Italia con la dimora in Parma del
+            cavalier Federico Zuccaro, dove si narrano le feste fatte in Mantova e le nozze del
+            principe Francesco Gonzaga coll’infanta Margherita di Savoia,</title>
+         <pubPlace>Bologna</pubPlace>
+         <date>1608</date>, <extent>in 4 pic.</extent>
+      </bibl>
+   </item>
+   <item xml:id="c1d1e7424" n="247">
+      <label>247.</label>
+      <bibl>
+         <author>ZUCCARI</author>, <title>La dimora in Parma del sig. cavalier Federico Zuccaro,
+            colle feste e trionfi maravigliosi celebrati in Mantova,</title>
+         <pubPlace>Bologna</pubPlace>
+         <date>1608</date>, <extent>in 4.</extent>
+      </bibl>
+      <note>Tutti questi opuscoletti di Federico Zuccari sono della più gran rarità, non tanto per
+         essere estesi da un artista, quanto perché vennero stampati in piccol numero di copie e
+         divulgati senza farsene mai la seconda edizione.</note>
+   </item>
+   <item xml:id="c1d1e7497" n="249" corresp="dcl:trp">
+      <label>249.</label>
+      <bibl>
+         <author>BENINCASA Bartolommeo</author>, <title>Descrizione della raccolta di stampe del
+            cavalier Durazzo, esposta in una dissertazione sull’arte dell’intaglio e stampa, </title>
+         <pubPlace>Parma</pubPlace>
+         <date>1784</date>, <extent>in 4.</extent> Col ritratto in principio del collettore.</bibl>
+      <note>Bellissima edizione resa oggi rara.</note>
+   </item>
+   <item xml:id="c1d1e7817" n="260">
+      <label>260.</label>
+      <bibl>GORI GANDELLINI, <title>Notizie storiche degl’intagliatori,</title>
+         <pubPlace>Siene</pubPlace>, vol. 3, <date>1771</date>, <extent>in 8,</extent> colla
+         continuazione del P. de Angelis, vol. 12, leg. in 6, Siena dal 1808 al 1816.</bibl>
+      <note>Questa continuazione ripete tutti gli errori degli scrittori a lui precedenti,
+         riconfermando il cattivo, senza scegliere il buono od apportar alcuna nuova od utile
+         notizia.</note>
+   </item>
+   <item xml:id="c1d1e9171" n="310">
+      <label>310.</label>
+      <bibl>
+         <author>LE CLERC Sébastien</author>, <title>Les vrais principes du dessein suivis du
+            caractère des passions, gravés sur les desseins de Le Brun.</title>
+         <extent>92 tavole incise in 8 oblong.,</extent>
+         <pubPlace>Paris</pubPlace>. <note>Poco utile come opera elementare è questo libro; ma
+            eseguito con tutta la venustà propria di questo spiritoso incisore.</note>
+      </bibl>
+   </item>
+   <item xml:id="c1d1e9227" n="312">
+      <label>312.</label>
+      <bibl>
+         <author>COLOMBINA Gasparo padovano</author>, <title>Aggiuntivi li primi elementi della
+            simmetria, ossia commensurazione del disegno delli corpi umani e naturali al giovamento
+            delli studiosi di questa <pb type="cico" n="54"/>nobil arte. Autore Filippo Esegrenio,
+            pittore ed antiquario.</title>
+      </bibl>
+      <note>Senz’anno, nome, luogo di stampa, con 24 bellissime tavole intagliate in rame di prima
+         freschezza. – Per essere dello stesso autore ed amatore di belle arti abbiamo registrato
+         anche il seguente.</note>
+   </item>
+   <item xml:id="c1d1e10204" n="346" corresp="dcl:rbv">
+      <label>346.</label>
+      <bibl>
+         <author>DE PILES</author>, <title>Abrégé d’anatomie accomodé aux arts de peinture et
+            sculpture par François Tortebart, <pb type="cico" n="61"/>mis dans un ordre nouveau par
+            Rogier de Piles,</title>
+         <pubPlace>Paris,</pubPlace>
+         <extent> in fol. fig.</extent>
+      </bibl>
+      <note>Le dieci tavole di quest’opera furono copiate da quelle che trovansi nell’anatomia di
+         Vesalio, disegnate da Tiziano e vennero riprodotte la prima volta dal Tortebart nel
+         1668.</note>
+   </item>
+   <item xml:id="c1d1e10607" n="361" corresp="dcl:sg7">
+      <label>361.</label>
+      <bibl>
+         <author>TORTEBAT</author>, <title> Abregé d’Anatomie.</title> Vedi de Piles.</bibl>
+   </item>
+   <item xml:id="c1d1e11059" n="377" corresp="dcl:p8h">
+      <label>377.</label>
+      <bibl>
+         <title>ALBERTI Leon Baptistae,</title>
+         <title>Los diez libros de architectura traduzidos de latin en romance.</title>
+         <pubPlace>Madrid</pubPlace>
+         <date>1582</date>
+         <extent>in 8.</extent>
+      </bibl>
+      <note> L’edizione fu eseguita in casa di Alonsa Gomez, stampatore reale, ma il privilegio per
+         la stampa fu concesso a Francesco Loçano. Non vi sono tavole in questa versione.</note>
+   </item>
+   <item xml:id="c1d1e11113" n="379">
+      <label>379.</label>
+      <bibl>
+         <author>De ALBERTIS Baptistae</author> poetae laureati, <title>De Amore liber optimus
+            feliciter incipit (e in fine) Baptistae de Albertis poeta laureati opus de Amore
+            utilissimum feliciter finit 1471.</title>
+      </bibl>
+   </item>
+   <item xml:id="c1d1e11128" n="380">
+      <label>380.</label>
+      <bibl>
+         <author>De ALBERTIS</author>, Bap. de Alb. poet. Laur., <title>Opus preclarum in amoris
+            remedio feliciter incipit: e in fine: Baptistae de Albertis poetae laureati opus in
+            Amoris remedio utilissimum feliciter finit 1471.</title>
+      </bibl>
+      <note>Questi due opuscoli sono estesi in italiano, quantunque, il titolo sia espresso in
+         latino. Questa è l’edizione originale dell’Hecatomphila e della Deifira in caratteri
+         rotondi a 25 righe per pagina. Ciascuno dei due volumetti rilegati in ini solo conta 20
+         foglietti. Tanto il titolo, che il finale colla data è stampato in maiuscole. Santander
+         opina che possano essere stampati questi due opuscoli a Venezia da Clemente Padovano,
+         ch’egli denomina il Guttemberg dell’Italia. Vero è che sono d’un estrema rarità e
+         preziosità. Il nostro esemplare è di prima bellezza in vit.</note>
+   </item>
+   <item xml:id="c1d1e11147" n="381">
+      <label>381.</label>
+      <bibl>
+         <author>ALBERTI Leonis Baptistae</author>, <title> Opera, sive de cotnmodis, atque
+            incommodis litterarum, de iure, trivia, canis, apologi 100, editio princeps: sine loco
+            et anno et impressoris nomine.</title>
+      </bibl>
+      <note>Tacciono di quest’edizione i bibliografi De Bure, Brunet, Santander e motti altri da me
+         consultati. Il primo foglietto non contiene cbe le prime -quattro parole da noi qui sopra
+         indicate. A tergo comincia una dedicatoria di tutti questi opuscoli di Girolamo Massaimi a
+         Roberto Pucci, la quale finisce col 4 foglietto, enumerando molte opere dell’Alberti, così
+         facendo il suo elogio. Si vede da questa che era già stampato il trattato dell’architettura
+         iamdiu edititum; ma non pare che gli altri opuscoli fossero pubblicati. A tergo del 4
+         foglietto comincia il testo e continua per altri 48 foglietti, nell’ultimo de’ quali è
+         l’Errata e a tergo alcuni versi in lode dell’autore di Antonio Sabino imolese.
+         Probabilmente il libro è stampato a Firenze. Il carattere è rotondo e assai bello.
+         L’esemplare è intonso e conservatissimo, leg. ol.</note>
+   </item>
+   <item xml:id="c1d1e11791" n="404">
+      <label>404.</label>
+      <bibl>
+         <title>ARCHITETTURA (Volume di) civile, militare, idraulica, meccanica, balistica ec. Con
+            numerose tavola MS. della fine del sec. XVI,</title>
+         <extent> in fol.</extent>
+      </bibl>
+   </item>
+   <item xml:id="c1d1e11889" n="408" corresp="dcl:jjt">
+      <label>408.</label>
+      <bibl>
+         <author>BALDO Bernardino</author>, <title>Scamilli impares vitruviani,</title>
+         <pubPlace>Augustae Vindelicorum</pubPlace>
+         <date>1612,</date>
+         <extent> in 4, fig.</extent>
+      </bibl>
+   </item>
+   <item xml:id="c1d1e11913" n="409" corresp="dcl:98c dcl:b37 dcl:kzv">
+      <label>409.</label>
+      <bibl>
+         <author>BALDO Bernardino</author>, <title> Accedit de verborum vitruvianorum significatione
+            et vita Vitruvii eodem auctore et de maculis solaribus (stesso luogo ed anno).</title>
+         <note>Comparvero questi tre opuscoli (ma rilegati in questo volume) separatamente; nel
+            primo de’ quali confutansi le opinioni del Filandro, del Barbaro, del Bertano. Unita al
+            commento sui vocaboli da una vita di Vitruvio, che non sappiamo quanto esser possa
+            attendibile.</note>
+      </bibl>
+   </item>
+   <item xml:id="c1d1e11931" n="410" corresp="dcl:jjt dcl:98c">
+      <label>410.</label>
+      <bibl>
+         <author>BALDO Bernardino</author>, Altro esemplare dello stesso, che apparteneva al Tuano,
+         leg. mar. dor.</bibl>
+   </item>
+   <item xml:id="c1d1e12207" n="420">
+      <label>420.</label>
+      <bibl>BAROZIO Giacomo da Vignola, <title>Gli ordini dell’architettura,</title>
+         <pubPlace>Venezia,</pubPlace>
+         <publisher>Remondini,</publisher>
+         <extent>in 8, in 51 tav. in rame.</extent>
+         <note>Edizione appena servibile per i poveri e da consumarsi nelle scuole, M. 62.</note>
+      </bibl>
+   </item>
+   <item xml:id="c1d1e12729" n="438" corresp="dcl:wbs">
+      <label>438.</label>
+      <bibl>
+         <author>BLONDEL François</author>, <title> Discours sur l’architecture avec deux lettres,
+            la première sur un projet d’hotel pour la ville de Paris, la seconde sur differens
+            moyens propres à encourager les artistes,</title>
+         <pubPlace>Paris,</pubPlace>
+         <publisher>chez Jombert,</publisher>
+         <date>1771,</date>
+         <extent>en 8.</extent>
+      </bibl>
+   </item>
+   <item xml:id="c1d1e13011" n="448">
+      <label>448.</label>
+      <bibl>
+         <author>De BOUELLES Charles</author>, Aggiuntovi: <title>Peleiier Jacques médecin et
+            mathematicien de l’usage de la geometrie,</title>
+         <pubPlace>Paris</pubPlace>
+         <date>1573,</date>
+         <extent> in 4, fig.</extent>
+      </bibl>
+   </item>
+   <item xml:id="c1d1e13524" n="466">
+      <label>466.</label>
+      <bibl>
+         <author>CATANEO Pietro</author>, <title> Aggiuntovi: Verantii Fausti siceni machinae novae
+            rum declaratione latina, italica, hispanica, gallica et germanica,</title>
+         <pubPlace> Venetiis,</pubPlace> cum privilegiis, sine anno et impressoris nomine.
+            <note>Sono 49 tavole; aggiuntovi altre macchine e disegni vari.</note>
+      </bibl>
+   </item>
+   <item xml:id="c1d1e13545" n="467">
+      <label>467.</label>
+      <bibl>
+         <author>CATANEO Pietro</author>, <title>Lo studio d’architettura civile sopra gli ornamenti
+            di porte e finestre di Domenico de’ Rossi, italiano e tedesco. </title>
+         <pubPlace>Auspurg</pubPlace> senz’anno, <extent>in fol. fig. tavole 53.</extent>
+         <note>Il Veranzio non debb’essere di molto antica impressione <pb type="cico" n="83"
+            />poiché dimostra le nuove Procuratie in una tavola della Piazza S. Marco di Venezia
+            edificate col terzo piano ec. e quasi potrebbe determinarsi l’epoca, se il disegno è
+            abbastanza fedele, giacché non vedesi la loggietta alla torre. Singolare è però il porsi
+            lungo questa Piazza tre fontane, che egli pretendeva potere far sorgere d’acqua dolce
+            con poco dispendio. Le tavole sono di meschino intaglio e le nozioni non troppo chiare e
+            precise, non senza però qualche finezza di accorgimento.</note>
+      </bibl>
+   </item>
+   <item xml:id="c1d1e13712" n="473">
+      <label>473.</label>
+      <bibl>
+         <author>Du CERCEAU Jaques Androuet</author>, <title> Second livre d’architecture contenant
+            plusieurs ordonances de cheminées, lucarnes, portes, fenêtres etc. Avec les desseins de
+            dix sepultures toutes differentes,</title>
+         <pubPlace> Paris,</pubPlace>
+         <publisher>de l’imprimerie d’Andre Wechel,</publisher>
+         <date> 1561,</date>
+         <extent> in fol. fig., sonovi 74 disegni intagliati in rame.</extent>
+      </bibl>
+      <note>Questo libro un po’ bizzarro nelle invenzioni conserva ancora alquanto del buono stile
+         che fioriva allora più che in ogni tempo posteriore in Francia.</note>
+   </item>
+   <item xml:id="c1d1e14069" n="484" corresp="dcl:szr">
+      <label>484.</label>
+      <bibl>
+         <author>CRISTIANI</author>, <title> Trattato delle misure d’ogni genere, antiche e moderne:
+            con note letterarie e fisicomatematiche, a giovamento di qualunque architetto, </title>
+         <pubPlace>Roma</pubPlace>
+         <date>1760,</date>
+         <extent> in 4, fig.</extent>
+      </bibl>
+      <note>Tutte le opere di questo sommo matematico e ingegnere sono da tenersi in pregio fra le
+         migliori di questo genere.</note>
+   </item>
+   <item xml:id="c1d1e14123" n="486">
+      <label>486.</label>
+      <bibl>
+         <author>DECHALES Claudii Francisci</author>, <title> Cursus seu mundus mathematicus, ubi de
+            architectura civili et militari, de perspectiva et alia,</title>
+         <pubPlace>Lugduni</pubPlace>
+         <date>1690,</date>
+         <extent> in fol. fig., vol. 4.</extent>
+      </bibl>
+      <note>Trattasi in quest’opera di prospettiva, di architettura, del taglio delle pietre, e di
+         tutto ciò che può aver derivazione o sussidio dagli studi matematici. Ma nulla potrebbero
+         apprendervi quelli clic non avessero ricevute buone instituzioni, poiché ciò che riguarda
+         le belle arti è cosa accessoria e di cattivo gusto.</note>
+   </item>
+   <item xml:id="c1d1e15014" n="518">
+      <label>518.</label>
+      <bibl>
+         <author>GRAPALDI Francisci Maria</author>, <title>De partibus aedium, editio princeps, sine
+            loco et anno.</title>
+      </bibl>
+      <note>Nella prima carta sono due epigrammi l’uno del Beroaldo, l’altro del Grapaldi a Orlando
+         Pallavicino: segue un secondo foglietto colla dedica allo stesso Pallavicino; e incomincia
+         subito il testo diviso in due libri. In fine termina con un indirizzo dello stampatore
+         Angelo Ugoletto parmense al lettore. Senza che siavi espressamente segno di luogo, ed anno
+         e di contro nell’ultimo foglietto sono 8 versi di Bernardino Sassoguidano modenese e la
+         marca dell’Ugoletto. Sono in tutto 194 foglietti di stampa in bei caratteri rotondi,
+         esemplare bellissimo in mar. dor. di un’opera da tenersi in pregio.</note>
+   </item>
+   <item xml:id="c1d1e15752" n="544">
+      <label>544.</label>
+      <bibl>
+         <author>LAUDROMO Sitonio</author>, <title>Saggio dell’architettura civile, ovvero regole
+            pratiche di capimastri e padroni di fabbriche. Edizione seconda,</title>
+         <pubPlace>Milano</pubPlace>
+         <date>1770,</date>
+         <extent>in 8.</extent>
+      </bibl>
+      <note>Libro pieno di pratiche e avvertenze per le comodità interne negli edifici.</note>
+   </item>
+   <item xml:id="c1d1e15997" n="553" corresp="dcl:pk3">
+      <label>553.</label>
+      <bibl>
+         <author>MARCHI Francesco</author>, <title>Architettura militare illustrata da Luigi
+            Marini,</title>
+         <pubPlace>Roma</pubPlace>
+         <date>1810</date>
+         <extent>in 4 gr., tomi 3 legati in 6 volumi.</extent> Con due volumi in foglio atlantico,
+         che contengono le tavole.</bibl>
+      <note>Furono tirate anche alcune copie del testo nella stessa carta grande delle tavole e vide
+         la luce a spese d’un gran mecenate, caldo di vero zelo, per la gloria italiana. Questa è la
+         più splendida fra le opere che trattino dell’arte militare. Si era già resa introvabile
+         l’antica edizione di Brescia del 1599 e da questo motivo fa indotto il Duca Melzi a
+         incaricare il <pb type="cico" n="99"/>sig. Marini di questa edizione preceduta da molti
+         prolegomeni, da una biblioteca storico-critica di fortificazione, da una nuova lezione e
+         commenti del testo e finalmente dell’antico testo originale. Il tutto illustrato da
+         copiosissime tavole.</note>
+   </item>
+   <item xml:id="c1d1e16429" n="568">
+      <label>568.</label>
+      <bibl>
+         <title>&gt;MISCELLANEA di molte stampe d’ornamenti, di figure ec.</title>
+      </bibl>
+      <note>Comincia col libro dei grotteschi di Simone Vovet intagliati da Dovigny. Poi gli ornati
+         di Ducerrean intagliati da Poilly, gli ornati di Raffaello pubblicati da la Guertiere, i
+         fregi del Mitelli; le Bar [...] de Pieret e molte statue e figure prese da Rafaello
+         pubblicate da Mariette; in tutto dugento [...].</note>
+   </item>
+   <item xml:id="c1d1e16692" n="577" corresp="dcl:sbw">
+      <label>577.</label>
+      <bibl>
+         <author>NATIVELLE Pierre</author>, <title>Nouveau traité d’architecture contenant les cinq
+            ordres suivant les quatres auteurs les plus approuvés,</title>
+         <extent>enrichi de 125 planches, 2 vol. in fol. atlant,</extent>
+         <pubPlace>Paris,</pubPlace>
+         <publisher>chez Dupuis,</publisher>
+         <date>1729.</date>
+      </bibl>
+      <note>Nel primo volume sono dati gli ordini secondo il Vignola col suo proprio testo e le
+         interpretazioni; un secondo sono dati i medesimi ordini secondo il testo di Palladio. Le
+         tavole in grandissima dimensione sono intagliate con gran lusso, m <pb type="cico" n="104"
+         />le parti ornamentali in ciascuna dimostrazione degli ordini, eseguite poi secondo il
+         gusto e l’idea dell’autore, in tempi di corruzione nelle arti, deturpano un’opera che è
+         concepita assai grandiosamente.</note>
+   </item>
+   <item xml:id="c1d1e17007" n="588">
+      <label>588.</label>
+      <bibl>
+         <author>OSII Theodati</author>, <title>De architecturae et agrimensurae nobilitate,</title>
+         <pubPlace>Mediolani</pubPlace>
+         <date>1639,</date>
+         <extent> in 8.</extent>
+      </bibl>
+      <note>Opuscoletto in caratteri corsivi.</note>
+   </item>
+   <item xml:id="c1d1e17738" n="613">
+      <label>613.</label>
+      <bibl>
+         <author>POLIPHILI (Francisci Columnae)</author>, <title>Hypnerotomachia, ubi humana omnia
+            nonnisi somnium esse docet etc. (opus a Leonardo Grasso Veronensi editum),</title>
+         <pubPlace>Venetiis,</pubPlace> mense Decembris, <date>1499</date>, <publisher>in aedibus
+            Aldi Manutii,</publisher>
+         <extent>in fol. fig.</extent>
+      </bibl>
+      <note>Prima edizione intatta, di margine massimo, esemplare di prima conservazione, ore tutte
+         le figure e quella del sagrifizio a Priapo sono intatte. Legato con somma magnificenza in
+         cuoio di Russia dorato.</note>
+   </item>
+   <item xml:id="c1d1e18098" n="625">
+      <label>625.</label>
+      <bibl>
+         <author>PRETI Francesco-Maria</author>, <title>Ragionamento sopra i principi
+            d’architettura,</title>
+         <pubPlace>Padova</pubPlace>
+         <date>1795,</date>
+         <extent>in fol. pic.</extent>
+      </bibl>
+   </item>
+   <item xml:id="c1d1e18122" n="626" corresp="dcl:65p">
+      <label>626.</label>
+      <bibl>
+         <author>QUENOT F.</author> sculpteur et architecte, <title>Livre d’architecture, où il
+            enseigne la facilité de <fw type="foot"/>
+            <pb type="memofonte"/>
+            <fw type="head"/> l’architecture et la réduction de chaque corps au pétit pied,</title>
+         <date>1659,</date>
+         <extent>in fol. fig.</extent>
+      </bibl>
+   </item>
+   <item xml:id="c1d1e18450" n="637a">
+      <bibl> Le ROUX G. B., Vedi Boissard Robert, nouveaux lambris de Galerie etc.</bibl>
+   </item>
+   <item xml:id="c1d1e18568" n="642" corresp="dcl:b5g">
+      <label>642.</label>
+      <bibl>
+         <title>SAGGIO sopra l’architettura gotica,</title>
+         <pubPlace>Livorno</pubPlace>
+         <date>1766,</date>
+         <extent>in 8.</extent>
+      </bibl>
+      <note>Opuscoletto di 32 pagine scritto con critica e profondità di cognizioni.</note>
+   </item>
+   <item xml:id="c1d1e18654" n="645">
+      <label>645.</label>
+      <bibl>
+         <author>SALVIATI Giuseppe</author>, <title>Regola di far perfettamente <pb type="cico"
+               n="117"/> compasso la voluta del capitello ionico,</title>
+         <pubPlace>Venezia</pubPlace>
+         <date>1552,</date>
+         <extent>in fol., M. 83.</extent>
+      </bibl>
+      <note>Questa non è che la ristampa del rarissimo opuscolo riprodotta per cura del Prof. Giovan
+         Antonio Selva in Padova nel 1814. Vedi all’Articolo Selva.</note>
+   </item>
+   <item xml:id="c1d1e18876" n="653" corresp="dcl:cgd">
+      <label>653.</label>
+      <bibl>
+         <author>SCAMOZZI</author>, <title>L’architettura universale di nuovo ristampata con vari
+            disegni in rame,</title>
+         <pubPlace>Venezia</pubPlace>
+         <date>1694,</date>
+         <extent> in fol. fig.,</extent>
+         <publisher>presso Girolamo Albrizzi.</publisher>
+      </bibl>
+      <note>Questa è precisamente l’edizione che fu intitolata al Cardinal Panfilio coi rami
+         dell’edizione di Piazzola, li quali non sono in alcun modo da compararsi a quelli della
+         prima edizione. Di queste due ristampe e di questa ultima in ispecie pochi bibliografi ne
+         hanno contezza.</note>
+   </item>
+   <item xml:id="c1d1e18976" n="656">
+      <label>656.</label>
+      <bibl>
+         <author>SCAMOZZI Vincenzo</author> architetto vicentino, <title>Discorsi sopra le antichità
+            di Roma con 40 tavole in rame, Venezia, presso Francesco Ziletti,</title>
+         <date>1583,</date>
+         <extent>in fol. p. fig.</extent>
+      </bibl>
+      <note>Queste tavole alla pittoresca vennero intagliate da Giovan Battista Pittoni vicentino.
+         Non fu mai fatta alcuna seconda edizione di quest’opera che ritiensi fra libri che hanno
+         pregio anche di rarità.</note>
+   </item>
+   <item xml:id="c1d1e19000" n="657">
+      <label>657.</label>
+      <bibl>
+         <author>SCAMOZZI Vincenzo</author>, <title>Sommario del viaggio, materie, fabbriche
+            notabili da Parigi sino in Italia per la via de Nancy,</title>
+         <date> l’anno 1600.</date>
+      </bibl>
+      <note>Questa è una copia legalmente estratta dal manoscritto originale esistente in casa
+         Tornieri a Vicenza, ove sono accuratamente disegnate tutte le fabbriche e piante, come
+         nell’originale, in 25 disegni a penna. Partì lo Scamozzi li 14 Marzo, ed arrivò li 11
+         Maggio a piccole giornate. Vedi Vitruvio coi commentari del Barbaro 1567.</note>
+   </item>
+   <item xml:id="c1d1e19052" n="659" corresp="dcl:9vs">
+      <label>659.</label>
+      <bibl>
+         <author>SCHEINER Cristoforo</author>, <title>Pratica del parallelogrammo da disegnare, di
+            nuovo data in luce da Giulio Troili, </title>
+         <pubPlace>Bologna</pubPlace>
+         <date>1653,</date>
+         <extent>in 8, fig.</extent>
+      </bibl>
+      <note>Con due tavole che esprimono il pantografo e il modo di usarne. Noti può dirsi questa
+         una versione, ma piuttosto un estratto dei precedente.</note>
+   </item>
+   <item xml:id="c1d1e19387" n="671">
+      <label>671.</label>
+      <bibl>
+         <author>SERLIO</author>, <title>Lo stesso libro extraordinario,</title>
+         <pubPlace>Lione</pubPlace>
+         <date>1560.</date> Vedi Labacco, cui va unito.</bibl>
+   </item>
+   <item xml:id="c1d1e19442" n="673" corresp="dcl:fkd">
+      <label>673.</label>
+      <bibl>
+         <author>SERLIO Sebastiano</author>, <title>Tercero y quarto libro de architettura <pb
+               type="cico" n="123"/> traduzido de toscano en lengua castellana per Francesco de
+            Villalpando architetto,</title>
+         <pubPlace>Toledo</pubPlace>
+         <date>1573,</date>
+         <extent>in fol. fig.</extent> In fine aqui fenesce el libro quarto de Sebastian Serlio
+         bolonés. Y fue impresso en Toledo en Casa de Joan de Ayala anno 1573.</bibl>
+      <note>Le tavole in legno sono tutte imitato materialmente e calcate su quelle delle anteriori
+         edizioni venete.</note>
+   </item>
+   <item xml:id="c1d1e19551" n="677" corresp="dcl:bk1">
+      <label>677.</label>
+      <bibl>
+         <author>TAISNIER Giovanni Hannonio</author>, Opera nuova molto utile necessaria a tutti li
+         architettori, geometri, ec. nella quale s’insegna la perfezione della misura di un’altezza,
+         larghezza, lunghezza e profondità con grandissima facilità, Ferrara, nella stamperia di
+         Giovanni de Buglhat, e Antonio Hucher, compagni nel mese d’aprile 1348, in 8, fig.</bibl>
+      <!--Where does the title end?-->
+      <note>Libretto di trentadue foglietti con varie tavole intagliate in legno: operetta singolare
+         e non facile a trovarsi.</note>
+   </item>
+   <item xml:id="c1d1e19620" n="680" corresp="dcl:pvn">
+      <label>680.</label>
+      <bibl>
+         <author>TOMMASIO (Christ)</author>, <title>Non Ens actionis forensis contra aedificatitem
+            ex emulatione, Halae Magdeb.</title>
+         <date>1735,</date>
+         <extent>in 4, M. 45.</extent>
+      </bibl>
+   </item>
+   <item xml:id="c1d1e19641" n="681">
+      <label>681.</label>
+      <bibl>
+         <author>VALTURII Roberti</author>, <title>De re militari lib. XII,</title>
+         <pubPlace>Verona</pubPlace>
+         <date> anno D. 1472,</date>
+         <extent>in fol. fig.</extent>
+      </bibl>
+      <note><p>Edizione prima e rara di questo libro; legato in mar dor. Il nostro esemplare combina
+            colla descrizione datane dal de Bure e da altri bibliografi, cominciando coi quattro
+            foglietti Elencus ossia Index rerum, indi la prefazione che incomincia Credo equidem e
+            il fine ove sono li 32 versi latini, i quali cominciano Valturii nostrae Princeps
+            altissime linguae, e terminano Teque sequi ec. indi: Johannes ex Verona oriundus Nicalai
+            Cyrurgie meidici filius, Artis impressorias magister, hunc de re militari librum
+            elegantissimum litteris et figuratis signis, sua in Patria, impressit an. 1472.</p>
+         <p>La preziosità singolare di questo libro è nelle stampe in legno eseguite probabilmente
+            da Matteo Pasti Veronese, il quale unitamente a Vittore Pisano detto Pisanello, pur
+            veronese, lavorò molto per li Malatesti di Rimino: e per conseguenza anche questi
+            disegni che illustrarono un’opera di autore Ariminese dedicata a Sigismondo Pandolfo
+            Malatesta possono essere stati eseguiti da uno di quegli artefici, che erano per
+            l’ingegno loro non, solo più chiari in Verona, dove il libro venne stampato, ma anche
+            più accetti a que’ Mecenati sotto il cui dominio ogni ramo d’arte e di lettere godeva di
+            nobilissima protezione. 82 sono le stampe sparse fra il testo, alcune delle quali
+            difficili e complicate per la prospettiva, sono mirabilmente disegnate, in tutto ciò che
+            alla figura umana appartiene: non veggiamo che siasi eseguita cosa migliore in
+            quell’epoca, in cui le scuote della Germania vantavano uomini chiari e contendevano
+            all’Italia il primato nel <pb type="cico" n="125"/> le arti dell’intaglio e della
+            stampa. L’Esopo del Tuppo è di gran lunga inferiore in merito di disegno, quantunque
+            prodotto una dozzina d’anni dopo e ragionevolmente tengasi in tanto pregio. Aggiungiamo
+            che lo stesso Valturio era disegnatore, come il riferiscono alcune lettere dal Battara
+            riportate nella Raccolta Milanese: ma appunto esaminando le tavole del Valturio
+            trovatisi differenze notabili fra alcune che possono essere tracciate da un ingegnere
+            semplicemente e altre da un peritissimo artista. Oltre di che, giova notare la molta
+            somiglianza, che passa tra alcuni disegni di queste figure e lo stile delle opere di
+            scultura, che veggiamo in alcuni bellissimi medaglioni di Matteo Pasto e di Vettor
+            Pisano, i quali erano in quell’età insigni nell’arte di modellare, dipingere, disegnate
+            ec. Poco o nulla sul merito di queste tavole si estendono gli scrittori. Il Papilou ne
+            tace, il sig. Ottley indica qualche cosa <fw type="foot"/>
+            <pb type="memofonte"/>
+            <fw type="head"/> sull’assertiva data dal Maffei nella sua Verona illustrata e si
+            riporta al fac simile che il sig Dibdin ha dato nella Spenceriana.</p></note>
+   </item>
+   <item xml:id="c1d1e19704" n="686" corresp="dcl:5zw">
+      <label>686.</label>
+      <bibl><author>VINGBOONS Philippe</author>, <title>Oeuvres d’architecture contenant les
+            desseins des principaux bâtimens dans le dernier agrandissement de la ville
+            d’Amsterdam</title>, 2 vol. rel. in 1 tom., à <pubPlace>la Haye</pubPlace>
+         <date>1786</date>. <note>Opera di gusto infelice con 74 tavole in rame. Questo libro unito
+            a quello di Pietro Post possono dare un’adeguata idea degli edifici olandesi in
+            generale.</note>
+      </bibl></item>
+   <item xml:id="c1d1e19741" n="691">
+      <label>691.</label>
+      <bibl><author>VITRUVII (Marci)</author>, <title>De architectura libri decem</title>. Codex
+         membranaceus com litteris aureopictis. Saeculi XIV. <note>Il codice è composto da 124
+            foglietti; sonovi alcune poche figure e i vocaboli greci al margine. Fu confrontato e
+            corrisponde, con piccolissime varietà e non essenziali, ai due principali della Vaticana
+            e per la bellissima sua conserva <pb type="cico" n="127"/> zione, e prima legatura e
+            lettere aurate, e nitidezza di pergamene il riteniamo di non comune preziosità.</note>
+      </bibl></item>
+   <item xml:id="c1d1e19747" n="692">
+      <label>692.</label>
+      <bibl><author>VITRUVII M.</author>, <title>De architectura libri tres</title>. Codex
+         membranaceus in fol. <note>Questo codice che non giunge se non a tutto il terzo libro è
+            stato cominciato col massimo lusso ed eleganza, essendo la prima pagina interamente
+            scritta a lettere d’oro e le due seguenti alternate in oro in lapis lazzuli e in
+            porpora: tutto il resto del codice in minio e in nero, è della massima bellezza: non è
+            però anteriore al XV secolo. Era nella biblioteca del Duca di Cassano.</note>
+      </bibl></item>
+   <item xml:id="c1d1e19753" n="693">
+      <label>693.</label>
+      <bibl><author>VITRUVII L. Pollionis</author>, <title>De architectura libri decem, editio
+            princeps.</title>
+         <note>Nel principio è la lettera di Giovanni Sulpizio al lettore: segue l’indice: poi la
+            lettera del Cardinal Riario a Giovanni Sulpizio: vengono i dieci libri di Viuuvio: che
+            finiscono con una carta di errata col registro. In fine Sexti Iulii Frontini Consularis
+            de acques quae in urbem influunt; libellus mirabilis. Dell’ultima carta è il registro
+            dei fogli, in fol., senza luogo ed anno. Questa è la più rara e pregiata edizione di
+            quest’opera per esser la prima non solo, ma perché il suo testo è bastantemente
+            corretto: esemplare magnifico in vit. dor. Era della biblioteca Corsini.</note>
+      </bibl></item>
+   <item xml:id="c1d1e19759" n="694">
+      <label>694.</label>
+      <bibl><author>VITRUVII L. Pollionis</author>, <title>De architectura libri decem sexti Julii
+            Frontini de aquaeductibus liber unus: Angeli Polidani opusculum: quod Panepistemen
+            inscribitur: Angeli Policiani in priora Analytica praelectio, cui titulus est
+            Lamia.</title>
+         <pubPlace>Florentiae</pubPlace> impressum anno a Natali Christiano <date>1496</date>, in
+         fol. <note>Non si può indovinare l’editore, né lo stampatore di questo testo, in cui
+            trovansi alcuni poche varietà dell’edizione principe ec. Tre o quattro figure di
+            semplici quadrati non bastano a poter dillo fra Vitruvii figurali: alcuni erroneamente
+            un tempo lo riputarono prima edizione. L’anno di stampa trovasi dopo il X libro prima
+            degli opuscoli e del Frontino. Il testo è preceduto da due soli foglietti colle tavole
+            dei capitoli e il frontespizio. In tutto il volume sono 86 foglietti. Esemplare di
+            bellissima conservazione.</note>
+      </bibl></item>
+   <item xml:id="c1d1e19765" n="695">
+      <label>695.</label>
+      <bibl><author>VITRUVII L. Pollionis</author>, <title>De Architectura libri decem</title>.
+         Accedunt Cleonidae Harmonicum Introdoctorium, Frontini de aquaeductibus. Policiani
+         opuscula, impressimi, <pubPlace>Venetiis</pubPlace>, per <publisher>Simonem
+            Papiensem</publisher>, dictum Bevilacqua, <date>1497</date>, in fol. <note>Le poche
+            varianti che incontranti in questa edizione dalla <pb type="cico" n="128"/> precedente
+            di Toscana non sono prese da alcun codice, né in alcun motto comprovate, ma dettate da
+            semplici conghietture: in tutto rassomiglia l’edizione fiorentina e non conosciamo se
+            alcun uomo di profonda dottrina ne procurasse la ristampa. Sono questi 91 foglietti di
+            stampa per l’aggiunta del Cleonide. L’anno di stampa sta dopo il decimo libro di
+            Vitruvio.</note>
+      </bibl></item>
+   <item xml:id="c1d1e19815" n="702">
+      <label>702.</label>
+      <bibl><author>VITRUVII</author>, <title>De architectura lib. X. Cum summa diligentia recogniti
+            et non nullis figuris sub hoc signo * positis</title>, sine loco <date>1523</date>, in
+         8. <note>Onde e novissime illustrazioni, correzioni e figure magistralmente segnate sui
+            margini. Non abbiamo altro che <fw type="foot"/>
+            <pb type="memofonte"/>
+            <fw type="head"/> conghietture da poter difficilmente azzardare sulla mano che con somma
+            dottrina lo impreziosì, poiché sebbene apparisca evidentemente scrittura del XVI secolo,
+            non avvi indizio dell’autore. Alcune emende e varianti sono giustificate non solo ma non
+            trovansi prodotte in alcuno dei commentatori che hanno scritto in quest’opera. Vedesi
+            che questi conosceva le lettere greche e latine infinitamente: e il lavoro è per lo più
+            esteso in italiano purgatissimo. Nitidi sono i caratteri: in principio sono 3 pagine di
+            minutissima forma intorno i pesi e misure. E non abbiamo trovato confrontare queste note
+            se non colle dottrine palladiane in tutti i luoghi che coincidono sullo stesso
+            argomento.</note>
+      </bibl></item>
+   <item xml:id="c1d1e19833" n="704">
+      <label>704.</label>
+      <bibl><author>VITRUVII</author>, <title>Altro esemplare simile al precedente</title>.
+      </bibl></item>
+   <item xml:id="c1d1e19933" n="718" corresp="dcl:nkb">
+      <label>718.</label>
+      <bibl><author>VITRUVIO M.</author>, <title>I dieci libri tradotti e commentati dal
+            Barbaro</title>, <pubPlace>Venezia</pubPlace>, appresso <publisher>il
+            Franceschi</publisher>, <date>1567</date>, in 4, fig. <note>Questo è l’esemplare
+            autografo mi quale studiò per diver <pb type="cico" n="134"/> si anni Vincenzo Scamozzi,
+            ed è tutto postillato di sua mano con incredibile ricchezza di osservazioni criticale e
+            preziosissime: sonovi pagine intere d’illustrazioni e da questo prezioso manoscritto
+            sarebbesi tratta una nuova e singolar edizione, in cui si sarebbero viste in conflitto
+            le opinioni degli uomini più dotti. Leggesi infine: «Fine sia alla fatica fatta da me
+            Vincenzo Scamozzi vicentino nel leggere Vitruvio, commentato da Monsig, Daniele Barbaro
+            eletto Patriarca d’Aquileia, per la terza volta, con l’havere notato tutte le cose
+            notabili ed in tutto ho trovalo come nelle postille margine si vedi a perla prima
+            lettera notato. E questo principiai li 4 aprile 1574 sino al di d’oggi li 2 Luglio 1574,
+            il che posso dire la prima volta che io il lessi, haverlo udito, la seconda, la quale fu
+            senza il comento del Zoppino, averlo goduto; e la terza che è questa, averlo giudicato:
+            nel che ho conosciuto quanto sia da seguirlo a chi vuole di tal fatica haver meritevol
+            frutto e così ogni studio voglio in esso porre, trovando che egli ha ragionato di tutte,
+            o almeno le più difficili e bisognevoli parti dell’architettura e bisogni
+            dell’architetto il che se molti conoscessero, non così facilmente si vanterebbero di
+            essere architetti, che appena sanno quello che gli appartiene. Vincenzo Scamozzi
+            Vicentino.» Questo esemplare appartenne all’architetto Selva, dopo la cui morte fu
+            acquistato dal conte Rizzo Patarol, il quale veggendo che poteva con decoro illustrare
+            questa nostra serie di vitruviane preziosità, ce ne fece con nobilissima munificenza il
+            generosissimo dono, sebbene sia egli fornito d’altre molte sontuosità in materia di
+            libri i più ricercati.</note>
+      </bibl></item>
+   <item xml:id="c1d1e19946" n="720">
+      <label>720.</label>
+      <bibl><author>VITRUVIO Marco</author>, <title>I dieci libri d’architettura tradotti e
+            commentati dal Barbaro</title>, <pubPlace>Venezia</pubPlace>, per <publisher>il
+            Franceschi</publisher>, <date>1584</date>, in 4, fig. <note>Quest’edizione non è che
+            un’esatta riproduzione dell’altra italiana del 1567 e colle stesse figure in
+            legno.</note>
+      </bibl></item>
+   <item xml:id="c1d1e19952" n="721" corresp="dcl:bcx">
+      <label>721.</label>
+      <bibl><author>VITRUVII Marci Pollionis</author>, <title>De architectura libri decem cura notis
+            Philandri</title>, apud <publisher>Tornesium</publisher>
+         <date>1586</date>, <pubPlace>Lugduni</pubPlace>, in 4, fig. </bibl></item>
+   <item xml:id="c1d1e19964" n="723" corresp="dcl:790">
+      <label>723.</label>
+      <bibl><author>M. VITRUVIO</author>, <title>I dieci libri dell’architettura tradotti in tedesco
+            dal Rivio</title>, <pubPlace>Basilea</pubPlace>
+         <date>1614</date>, in foglio figurato. <note>Questo medico studiosissimo d’ogni modo di
+            belle cognizioni, sebbene non profondissimo, fu il primo a tradurre Vitruvio in tedesco.
+            La prima edizione la pubblicò a Norimberga nel 1548, e poscia nel 1755 a Basilea.
+            Quest’ultima edizione dicesi ricorretta ed ampliata, ma con pochissime variazioni dalle
+            precedenti. Le tavole in legno numerosissime e singolari, di che è fornita
+            quest’edizione, sono le stesse delle altre edizioni ec. Molte di queste aveva prima
+            prodotte nel 1547 nella sua opera di architettura e prospettiva. Vedi Rivio.</note>
+      </bibl></item>
+   <item xml:id="c1d1e19982" n="725" corresp="dcl:wvn">
+      <label>725.</label>
+      <bibl><author>VITRUVIO M.</author>, <title>I dieci libri dell’architettura tradotti e
+            commentati da Monsig. Daniele Barbaro</title> ed ora in questa nuova impressione per
+         maggior comodità del lettore le materie di ciascun libro ridotte sotto capi,
+            <pubPlace>Venezia</pubPlace>, presso <publisher>Alessandro de’ Vecchi</publisher>,
+            <date>1629</date>. <note>Quest’edizione è presa dalla precedente del 1567 colla
+            differenza di essere assai meno corretta, ed essendo state dallo stampatore in più
+            luoghi omesse tavole necessarie, o sostituite alcune altre che non hanno che fare col
+            testo. Ma ciò che è più strano si è che il de’ Vecchi editore, ponendo il suo nome al
+            proemio che aveva prodotto il Franceschi nella più antica citata edizione, ove parla del
+            Barbaro si esprime come se avesse avuto dialogo con lui nelle materie vitruviane ed era
+            morto 59 anni prima di questa seconda edizione: il che prova che ristampò e fece suo il
+            proemio del Franceschi, senza leggerlo.</note>
+      </bibl></item>
+   <item xml:id="c1d1e20027" n="731" corresp="dcl:737">
+      <label>731.</label>
+      <bibl><author>VITRUVIO</author>
+         <title>(di) Compendio dell’architettura di M. Perrault di nuovo compendiata e ristretta da
+            C. C. C. con figure in rame delineate e intagliate da Filippo Vasconi</title>,
+            <pubPlace>Venezia</pubPlace> presso <publisher>Girolamo Albrizzi</publisher>,
+            <date>1711</date>, in 8, fig. <note>Le tre lettere indicate vogliono significare il
+            Conte Carlo Cataneo. Questo restringe anche maggiormente il compendio del Perrault e lo
+            limita alle sole nozioni dell’architettura civile. Le tavole poi intagliate dal Vasconi
+            sono affatto senza eleganza.</note>
+      </bibl></item>
+   <item xml:id="c1d1e20046" n="734" corresp="dcl:9pk">
+      <label>734.</label>
+      <bibl><author>M. VITRUVIO Pollion</author>, <title>Los diez libros de architectura traducidos
+            del latin, y commentados por D. Joseph Ortiz y Sanz</title>, en
+            <pubPlace>Madrid</pubPlace>, en <publisher>la imprenta Real</publisher>,
+            <date>1787</date>, in fol. <note>Aveva già questo commentatore dato altri saggi dei suoi
+            studi vitruviani e dopo l’edizione del Galliani volle presentare nella stessa forma con
+            più lusso il Vitruvio alla Spagna. Il testo pei tipi, i 56 disegni per le incisioni, la
+            carta, tutto contribuì allo splendore di questa edizione: si attenne l’autore molto alle
+            versioni di Perrault e del Galliani.</note>
+      </bibl></item>
+   <item xml:id="c1d1e20060" n="736" corresp="dcl:7d3">
+      <label>736.</label>
+      <bibl><author>VITRUVIUS M. Pollio</author>, <title>The architecture traslated from the
+            original latin by W. Newton architect</title>, <pubPlace>London</pubPlace>
+         <date>1791</date>, 2 vol. in fol. fig. <note>Opera prodotta con tutto il lusso e l’eleganza
+            delle edizioni moderne inglesi, che non aggiunse per novità di interpetrazioni alcuna
+            maggior chiarezza a’ luoghi oscuri del testo: con 117 figure ben disegnate e intagliate
+            in rame. Esemplare distinto, in cuoio di Russia dor. ec.</note>
+      </bibl></item>
+   <item xml:id="c1d1e20146" n="748" corresp="dcl:n2r">
+      <label>748.</label>
+      <bibl><author>WEIDLERO (Jo. Frid.)</author>, <title>Dissertatio iuridica de usu remedii contra
+            aedificantem ad aemulationem</title>, <pubPlace>Vitembergae</pubPlace>
+         <date>1732</date>, in 4, M. 45.</bibl></item>
+   <item xml:id="c1d1e20167" n="750" corresp="dcl:bcz">
+      <label>750.</label>
+      <bibl><author>ARNALDI Co. Enea</author>, <title>Lo stesso</title>, seconda edizione,
+            <pubPlace>Vicenza</pubPlace>
+         <date>1783</date>, in 4, pic. fig. — <author>BECEGA Tom.</author>, <title>Saggi
+            d’architettura teatrale</title>. Vedi <title>Calderari Ottone</title>. </bibl></item>
+   <item xml:id="c1d1e20304" n="770">
+      <label>770.</label>
+      <bibl><author>NOVERRE M.</author>, <title>Observations sur la construction d’une nouvelle
+            salle de l’opera</title>, <pubPlace>Amsterdam</pubPlace>
+         <date>1787</date>, in 8, M. 95. <note>Un uomo, che ha calcato il teatro, ha scritto con
+            cognizione di causa e con infinito accorgimento questo opuscolo.</note>
+      </bibl></item>
+   <item xml:id="c1d1e20341" n="775">
+      <label>775.</label>
+      <bibl><title>RAGIONAMENTO intorno al nuovo Teatro di Bologna</title>,
+            <pubPlace>Ferrara</pubPlace> in 8, M. 3i. <note>Intendesi il gran teatro di
+            Bibiena.</note>
+      </bibl></item>
+   <item xml:id="c1d1e20347" n="776">
+      <label>776.</label>
+      <bibl><title>RÉFLÉXIONS d’un patriote sur l’opera française et sur l’opera italienne, qui
+            presente le paralèlle du goût des deux nations dans les beaux arts</title>,
+            <pubPlace>Losanne</pubPlace>
+         <date>1754</date>, en 8. — Aggiuntovi: <title>Essai sur la peinture, la sculpture, et
+            l’architetture</title>, <date>1751</date>. </bibl></item>
+   <item xml:id="c1d1e20421" n="785" corresp="dcl:vnw">
+      <label>785.</label>
+      <bibl><author>BIANCHI Pietro</author>, <title>Osservazioni sull’arena e sul podio
+            dell’anfiteatro Flavio</title>, illustrate e difese da Lorenzo de Romano,
+            <pubPlace>Roma</pubPlace>, nella stamperia de <publisher>Romanis</publisher>,
+            <date>1812</date>, in fol. fig. M. 81. <note>Con una gran tavola intagliata in rame. Fu
+            oggetto di molte discussioni un’escavazione in quell’anno fatta, che si dovette
+            fatalmente ricuoprire.</note>
+      </bibl></item>
+   <item xml:id="c1d1e20433" n="787">
+      <label>787.</label>
+      <bibl><author>BULENGERII Julii Cesaris</author>. <title>De theatro, ludisque scenicis libri
+            duo</title>: editio prima, <pubPlace>Tricassibus</pubPlace>
+         <date>1603</date>, in 8, fig. <note>Con tre tavole intagliate in rame.</note>
+      </bibl></item>
+   <item xml:id="c1d1e20446" n="789" corresp="dcl:166">
+      <label>789.</label>
+      <bibl><author>CARLI Gian. Rinaldo</author>, <title>Degli anfiteatri e particolarmente del
+            Flavio di Roma, di quello d’Italica <pb type="cico" n="147"/> nella Spagna e di quello
+            di Pola nell’Istria</title>, <pubPlace>Milano</pubPlace>
+         <date>1788</date>, in 4, fig. <note>Quest’opera è anche stampata nelle antichità italiche
+            di questo autore con 15 tavole intagliate in rame.</note>
+      </bibl></item>
+   <item xml:id="c1d1e20634" n="814">
+      <label>814.</label>
+      <bibl><author>BOETII Anitii Manilii Severi</author>, <title>Aritmetice, V. all’artic.
+            Margarita Philosophica, nell’Erudizione Varia, con cui è legato.</title>
+      </bibl></item>
+   <item xml:id="c1d1e20658" n="818">
+      <label>818.</label>
+      <bibl><author>BOSSE Abram, Et M. du Boccage</author>
+         <title>Lettres</title>, <pubPlace>Paris</pubPlace>
+         <date>1668</date>, in 8. <note>Questo è un opuscoletto di sole 23 pagine in caratteri
+            minutissimi, ove sono discussi tra questi due personaggi alcuni argomenti interessanti
+            di belle arti.</note>
+         <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+         <pb type="cico" n="152"/>
+      </bibl></item>
+   <item xml:id="c1d1e20722" n="827">
+      <label>827.</label>
+      <bibl><author>Du CERCEAU Jacques Audronet</author>, <title>Leçons de perspective
+            positive</title>, à <pubPlace>Paris</pubPlace>, par <publisher>Mamert
+            Patisson</publisher>
+         <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/> imprimeur, <date>1576</date>, in fol. fig. <note>La più rara tra le opere
+            pubblicate di questo autore mai veduta dal Comolli e taciuta dal Tirloy nel suo
+            Dizionario d’Architettura, con 60 tavole intagliate in rame e altrettante illustrazioni,
+            intitolate Lezioni.</note>
+      </bibl></item>
+   <item xml:id="c1d1e20861" n="847">
+      <label>847.</label>
+      <bibl><author>MAROLOIS Samuelis</author>, <title>Mathematicorum sui saeculi facile principis
+            opticae, sive perspectivae <fw type="foot"/>
+            <pb type="memofonte"/>
+            <fw type="head"/> partes quatuor</title>, <pubPlace>Amstelodami</pubPlace>,
+            <publisher>Janson</publisher>, <date>1633</date>, in fol. fig. Prima edizione. — Addita
+            <author>Joan. Uredernanni</author>, <title>Perspectivae pars secunda</title>,
+            <pubPlace>Amstelodami</pubPlace>
+         <date>1633</date>. <note>Quest’opera contiene la seconda parte, cioè la scenografia eguale
+            a quella pubblicata nel 1638 con 80 tavole e 24 ne sono nel trattato di Uredeman.</note>
+      </bibl></item>
+   <item xml:id="c1d1e20968" n="862" corresp="dcl:4cj">
+      <label>862.</label>
+      <bibl><author>TAYLOR et Mourdoc</author>, <title>Traduction de deux ouvrages, l’une angloise,
+            l’autre latine sur les nouveaux principes de perspective linéeaire, avec un’essai sur le
+            melange des couleurs par Newton</title>: avec fig., <pubPlace>Amsterdam</pubPlace>
+         <date>1757</date>, en 8. <note>Con 6 tavole-in rame. Opera escita dopo la traduzione
+            italiana del P. Jaquier.</note>
+      </bibl></item>
+   <item xml:id="c1d1e21043" n="871">
+      <label>871.</label>
+      <bibl><author>VISENTINI Antonio</author>, <title>L’introduzione della soda e reale
+            architettura e prospettiva</title>; manoscritto. <note>Questo Visentini fu maestro nel
+            secolo scorso della pubblica Accademia Veneta e scrisse questo trattato prospettico per
+            erudire la gioventù. Lo ornò di 81 figure, che sono quadri di composizione sua,
+            acquarellati in chiaroscuro per essere poi intagliati, e pubblicati nell’opera. Il
+            dispendio che avrebbe costato quest’edizione ritenne forse l’autore dal darla alla luce.
+            Sebbene se fosse stata eseguita, come la sua seconda parte degli Errori del Gallacini,
+            non vi si sarebbe troppo lodata l’accuratezza e il buon gusto. Vedi GALLACINI ec.</note>
+      </bibl></item>
+   <item xml:id="c1d1e21049" n="872">
+      <label>872.</label>
+      <bibl><author>VITELLIONIS Mathematici doctissimi</author>, <title>Optice, id est de natura,
+            ratione, projectione radiorum visus, luminum, colorum, etc. quam vulgo perspectivam
+            vocant</title>, libri X. <pubPlace>Norimbergae</pubPlace>
+         <date>1551</date>, in fol. fig. </bibl></item>
+   <item xml:id="c1d1e21104" n="878" corresp="dcl:kh9">
+      <label>878.</label>
+      <bibl><author>AULISII Dominici</author>, <title>Opuscula de Gymnasii costructione, mausolei
+            architectura, harmonia timaica et numeris medicis</title>: hic accessit de colo
+            <publisher>Mayerano</publisher>, <pubPlace>Neapoli</pubPlace>
+         <date>1694</date>, in 4. <note>Stanno ai luoghi de’ rispettivi opuscoli le tavole
+            illustrative.</note>
+      </bibl></item>
+   <item xml:id="c1d1e21125" n="881">
+      <label>881.</label>
+      <bibl><author>BELLI Silvio</author>, <title>Libro del misurar colla vista</title>. Vedi Ceredi
+         Giuseppe, cui va unito. </bibl></item>
+   <item xml:id="c1d1e21199" n="892">
+      <label>892.</label>
+      <bibl><author>CATENA Pietro</author>, <title>Il trattato della sfera</title>,
+            <pubPlace>Patavi</pubPlace>
+         <date>1561</date>, in 8. Vedi in <author>Palladio</author>
+         <title>Antichità di Roma</title>
+         <date>1554</date> in 8. </bibl></item>
+   <item xml:id="c1d1e21229" n="896">
+      <label>896.</label>
+      <bibl><author>CEREDI Giuseppe</author>, Aggiuntovi <title>Belli Silvio Vicentino</title>,
+         Libro del misurar colla vista, <pubPlace>Venezia</pubPlace>, presso <publisher>Giordano
+            Ziletti</publisher>, <date>1566</date> in 4, pic. fig. <note>Operette dotte e ingegnose
+            di uomini sommi per l’età in cui vissero, colle tavole ben disegnate ed intagliate in
+            legno.</note>
+      </bibl></item>
+   <item xml:id="c1d1e21235" n="897" corresp="dcl:f8s">
+      <label>897.</label>
+      <bibl><title>CHIMNEYS, A pratical treatise on Chimneys containing full directions for
+            preventing or removing smocke in houses illustrated with copper plates</title>,
+            <pubPlace>Edimburgh</pubPlace>
+         <date>1776</date>, in 8. </bibl></item>
+   <item xml:id="c1d1e21281" n="904" corresp="dcl:0kw">
+      <label>904.</label>
+      <bibl><author>DESMAREST</author>, <title>Lettre sur les differentes sortes de pouzzolanes et
+            particulierement sur celles qu’on peut tirer de l’Auvergne</title>,
+            <pubPlace>Paris</pubPlace>
+         <date>1779</date>, in 8, M. 63. Con due tavole. </bibl></item>
+   <item xml:id="c1d1e21287" n="905" corresp="dcl:0wk">
+      <label>905.</label>
+      <bibl><title>DESCRIZIONE della stufa di Pensilvania inventata dal Sig. Fraudili</title>,
+            <pubPlace>Venezia</pubPlace>
+         <date>1788</date>, in 8, fig. M. <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/> 51. <note>Con una tavola intagliata in rame.</note>
+      </bibl></item>
+   <item xml:id="c1d1e21387" n="920" corresp="dcl:0dh">
+      <label>920.</label>
+      <bibl><author>GAUTIER Architecte</author>, <title>Traité des ponts ou il est parlé de ceux des
+            Romains et de ceux des Modernes ec. avec une dissertation à la fin sur les culées,
+            piles, voussoirs et poussées des ponts etc</title>, Quatrieme e <pb type="cico" n="170"
+         /> dition augmentée etc. Tome premier, le traité de chemins faisant le t. second,
+            <pubPlace>Paris</pubPlace>
+         <date>1765</date>. <note>Sonovi 36 tavole oltre il frontespizio e 4 tav. addizionali per la
+            dissertazione sui piloni: opera eseguita da un valente architetto.</note>
+      </bibl></item>
+   <item xml:id="c1d1e21451" n="929">
+      <label>929.</label>
+      <bibl><author>HERRONE</author>, Aggiuntavi <title>la compendiosa introduzione alla prima parte
+            della specularia, cioè della scienza degli specchi di Rafani Mirami Ebreo, fisico e
+            mattematico</title>, <pubPlace>Ferrara</pubPlace>
+         <date>1582</date>. </bibl></item>
+   <item xml:id="c1d1e21475" n="933" corresp="dcl:0wm">
+      <label>933.</label>
+      <bibl><author>HOWARD John</author>, <title>The state of the prisons in England and Wales, with
+            preliminary observations and an account of some forcing prisons</title>,
+            <pubPlace>Warrington</pubPlace>
+         <date>1774</date>, in 4, fig. </bibl></item>
+   <item xml:id="c1d1e21547" n="943">
+      <label>943.</label>
+      <bibl><author>MONTANARI Geminiano</author>, <title>La livella diottrica</title>,
+            <pubPlace>Venezia</pubPlace>
+         <date>1680</date>, in 8. Vedi in <author>Palladio</author>, <title>Antichità di
+            Roma</title>, <date>1554</date>, cui è unito. </bibl></item>
+   <item xml:id="c1d1e21572" n="947" corresp="dcl:55s">
+      <label>947.</label>
+      <bibl><author>PERINI Lodovico</author>, <title>Geometria pratica per misurar terre, acque,
+            fiumi, pietre, grani, fabbriche, ed altro</title>. </bibl></item>
+   <item xml:id="c1d1e21623" n="954">
+      <label>954.</label>
+      <bibl><author>RAMELLI Agostino</author>, <title>Le diverse ed artificiose macchine composte in
+            lingua italiana e francese</title>, <pubPlace>Parigi</pubPlace>, in casa
+            del<publisher>l’autore</publisher>, <date>1588</date> in fol. fig. <note>Questo si
+            riguarda da tutti i bibliografi come la pia ricca, rara, e bella opera in materia di
+            meccaniche, non tanto per la copia di 195 tavole, quanto per le illustrazioni in
+            italiano e in francese e per la nitidezza delle incisioni. Avvi in principio un ritratto
+            dell’autore. Esemplare di bellissima conservazione.</note>
+      </bibl></item>
+   <item xml:id="c1d1e21635" n="956" corresp="dcl:b8k">
+      <label>956.</label>
+      <bibl><title>RIFLESSIONI sopra una pietra flessibile pretesa elastica</title>, che si conserva
+         nel Palazzo Borghese in Roma, <pubPlace>Roma</pubPlace>
+         <date>1783</date>, in 4, M. 15. <note>Posteriormente all’opera in cui fu scritta questa
+            memoria si sono riconosciute in quantità queste pietre che incontratisi in molti musei e
+            i progressi della zoologia hanno fatto scemare la meraviglia, o spiegato l’indole di
+            molti fenomeni.</note>
+      </bibl></item>
+   <item xml:id="c1d1e21641" n="957">
+      <label>957.</label>
+      <bibl><author>Della ROSA Saverio</author>, <title>Progetto d’una rotonda pel mercato delle
+            biade nella piazza della Brà in Verona</title>, <pubPlace>Ver.</pubPlace>
+         <date>1819</date>. <note>Con due tavole, in 4.</note>
+      </bibl></item>
+   <item xml:id="c1d1e21826" n="983">
+      <label>983.</label>
+      <bibl><author>DOISSIN Ludovico</author>. Vedi <author>Carli</author>. </bibl></item>
+   <item xml:id="c1d1e22084" n="1020">
+      <label>1020.</label>
+      <bibl><author>GAMBARAE (Laurentii)</author>, <title>Poemata, ubi arcis Caprarolae descriptio
+            ec.</title>, <pubPlace>Antuerpie</pubPlace>, <publisher>Plantin</publisher>,
+            <date>1569</date>, M. 75. Edizione elegante. </bibl></item>
+   <item xml:id="c1d1e22117" n="1025">
+      <label>1025.</label>
+      <bibl><author>MANDRISIO Nicolò</author>, <title>Viaggi per l’Italia, Francia e Germania
+            descritti in versi con annotazioni copiose</title>: tomi 2, <pubPlace>Venezia</pubPlace>
+         <date>1718</date>, in 8. — Aggiunto in fine al primo tomo <title>un’orazione dello stesso
+            in rendimento di grazie per una sontuosa biblioteca aperta in Udine al pubblico da
+            Dionigio Delfino Patriarca d’Aquileia</title>, <date>1718</date>. <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+      </bibl></item>
+   <item xml:id="c1d1e22168" n="1032">
+      <label>1032.</label>
+      <bibl><title>OMAGGIO di riconoscenza al nobile Sig. Filippo Balbì per alcune pitture a fresco
+            di Paolo Cagliari trasportate da’ muri in tela e donate alla chiesa di San Liberale di
+            Castel-Franco</title>, <pubPlace>Venezia</pubPlace>
+         <date>1819</date>, in 8, M. 80. <note>Sono alcuni componimenti preceduti da una breve
+            memoria.</note>
+      </bibl></item>
+   <item xml:id="c1d1e22250" n="1044">
+      <label>1044.</label>
+      <bibl><author>STROZZI Giulio</author>, <title>La Venezia edificata</title>. Poema eroico cogli
+         argomenti del Sig. Francesco Cortesi, <pubPlace>Venezia</pubPlace>, presso
+            <publisher>Antonio Pinelli</publisher>, <date>1624</date>, in fol. fig. <note>Il Valesio
+            intagliò le tavole, il frontespizio, e il ritratto dell’autore. I canti sono 24,
+            ciascuno preceduto da una tavola. La prima fu disegnata da Bernardo Castello: le altre
+            certamente sono di meno perito artefice, o se del medesimo, assai
+         trascurate.</note></bibl></item>
+   <item xml:id="c1d1e22272" n="1046">
+      <label>1046.</label>
+      <bibl><author>BUONI Tommaso</author>, <title>I problemi della bellezza di tutti gli umani
+            affetti</title>, con un discorso della bellezza del medesimo autore,
+            <pubPlace>Venezia</pubPlace>
+         <date>1601</date>, in 12. <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+      </bibl></item>
+   <item xml:id="c1d1e22309" n="1051" corresp="dcl:s55">
+      <label>1051.</label>
+      <bibl><author>CROUSAZ</author>, <title>Traité du Beau où l’on montre en quoi consiste ce que
+            l’on nomme ainsi, par des exemples, tirés la plus part des arts et des sciences</title>,
+            <pubPlace>Amsterdam</pubPlace>
+         <date>1724</date>, 2 vol., in 12. </bibl></item>
+   <item xml:id="c1d1e22321" n="1053">
+      <label>1053.</label>
+      <bibl><author>DOMESICHI M. Lodovico</author>, <title>La nobiltà delle donne</title>,
+            <pubPlace>Venezia</pubPlace>, <publisher>Giolito</publisher>, <date>1649</date>, in 12.
+            <note>Libretto esteso con venustà e ripieno di belle notizie</note>. </bibl></item>
+   <item xml:id="c1d1e22510" n="1079">
+      <label>1079.</label>
+      <bibl><author>ARIOSTO Lodovico</author>, <title>Orlando Furioso</title>, nuovamente adornato
+         di figure in rame da Girolamo Porro, <pubPlace>Venezia</pubPlace>
+         <date>1584</date>, presso <publisher>il Franceschi</publisher>. <note>Questo esemplare al
+            canto 93 e 94 ha la medesima stampa <pb type="cico" n="191"/> ripetuta: in tutto il
+            resto è completo non mancando né al principio, né al fine di tutti i foglietti
+            addizionali citati dai Bibliografi. Li ultimi 43 foglietti preceduti da un frontespizio
+            intagliato da Giacomo Franco a parte partano la medesima data. La stampa 34, che non
+            trovasi in questo esemplare, deve rappresentare Astolfo che sorte dalla caverna delle
+            Arpie col cavallo volante. Le pagine del primo testo del poema colle illustrazioni e
+            note arrivano alla 654 e la tavola de’ principi di tutte le stanze occupa 16 foglietti:
+            e 19 fogli, compreso il frontespizio sono i prolegomeni che precedono il Poema.</note>
+      </bibl></item>
+   <item xml:id="c1d1e22522" n="1081">
+      <label>1081.</label>
+      <bibl><author>BAUR Jean Willelm</author>, <title>Le Metamorfosi d’Ovidio</title>, intagliate
+         in 150 tavole in rame di prima freschezza e bellezza, <date>1641</date> in 4. <note>Questa
+            prima edizione delle Metamorfosi è riportata sovra gran fogli atlantici.</note>
+      </bibl></item>
+   <item xml:id="c1d1e22676" n="1103">
+      <label>1103.</label>
+      <bibl><author>LANZI Luigi</author>, <title>Di Esiodo Ascreo: I Lavori e le Giornate</title>,
+         opera con 50 codici riscontrata, <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/> emendata la versione latina e aggiuntavi l’italiana in terza rima,
+            <pubPlace>Firenze</pubPlace>
+         <date>1807</date>, in 4, grand. </bibl></item>
+   <item xml:id="c1d1e22701" n="1106">
+      <label>1106.</label>
+      <bibl><author>OSSIAN</author>, <title>I Canti: Pensieri d’un anonimo</title>, disegnati ed
+         incisi a contorni. <note>L’anonimo indicato è il sig. Luigi Zandomeneghi scultore.</note>
+      </bibl></item>
+   <item xml:id="c1d1e22731" n="1111">
+      <label>1111.</label>
+      <bibl><author>SALLUSTIO Cayo Crispo</author>, <title>La conjuration de Catilina, y la guerra
+            de Jugurta</title>, en <pubPlace>Madrid</pubPlace>, par <publisher>Joachin
+            Ibarra</publisher>, <date>1772</date>, in fol. fig. spagnuolo e latino. <note>Splendida
+            edizione, col frontespizio intagliato e disegnato da Montfort, stampata uniformemente in
+            carta velina bianca senza il mescuglio della carta azzurra come trovasi in alcuni <pb
+               type="cico" n="197"/> esemplari. L’incisione delle <fw type="foot"/>
+            <pb type="memofonte"/>
+            <fw type="head"/> medaglie è classicamente eseguita, in ispecie le tavole intagliate da
+            Carmona.</note>
+      </bibl></item>
+   <item xml:id="c1d1e23015" n="1143">
+      <label>1143.</label>
+      <bibl><author>BOTTARI</author>, Vedi <title>Raccolta di Lettere Pittoriche</title>.
+      </bibl></item>
+   <item xml:id="c1d1e23021" n="1144">
+      <label>1144.</label>
+      <bibl><author>CANCELLIERI Francesco</author>, <title>Lettera sull’origine delle <pb
+               type="cico" n="206"/> parole Dominus e Domnus e del titolo Don</title>,
+            <pubPlace>Roma</pubPlace>
+         <date>1808</date>, in 8, M. 55. </bibl></item>
+   <item xml:id="c1d1e23033" n="1146" corresp="dcl:zbp">
+      <label>1146.</label>
+      <bibl><author>CERROTI Giovan Battista</author>, <title>Lettere critiche
+            architettonico-idrometriche</title>, <pubPlace>Firenze</pubPlace>, <date>1782</date>, in
+         fol. </bibl></item>
+   <item xml:id="c1d1e23115" n="1158">
+      <label>1158.</label>
+      <bibl><author>GAROFALO (Biagio)</author>, <title>Lettera intorno al busto
+         d’Asclepiade</title>. Articolo del Giornale de’ Letterati di Pisa: unitivi altri articoli
+         su alcuni trattati dei Bagni di <pubPlace>Lucca</pubPlace> e di <pubPlace>Pisa</pubPlace>,
+         in 12. M. 73. <note>Con una tavola intagliata in rame del busto d’Asclepiade.</note>
+      </bibl></item>
+   <item xml:id="c1d1e23177" n="1167" corresp="dcl:sc2">
+      <label>1167.</label>
+      <bibl><title>LETTERA ad un amico nella quale si dà contezza del Cavalier Carlo Giuseppe Ratti
+            pittor genovese</title>, in 8. <note>Questa è un’apologia in favore del Ratti contro
+            Francesco Milizia senza luogo ed anno.</note>
+      </bibl></item>
+   <item xml:id="c1d1e23396" n="1199" corresp="dcl:5gg">
+      <label>1199.</label>
+      <bibl><author>QUIRINI Angeli M.</author>, Ad Claris. <title>Symmacum Mazochium Epistola in
+            eius Schediasma de antiquis Corcyrae nominibus</title>, <pubPlace>Romae</pubPlace>
+         <date>1742</date>, in 4, M. 40. </bibl></item>
+   <item xml:id="c1d1e23415" n="1202" corresp="dcl:45r">
+      <label>1202.</label>
+      <bibl><title>RACCOLTA di lettere sulla pittura, scultura, architettura (riunite per opera e
+            cura del Bottari)</title>, vol. 7, <pubPlace>Roma</pubPlace>
+         <date>1754 al 1783</date>, in 4, pic. <note>Questa è la più preziosa raccolta di lettere
+            pittoriche che si conosca.</note>
+         <pb type="cico" n="213"/>
+      </bibl></item>
+   <item xml:id="c1d1e23423" n="1203">
+      <label>1203.</label>
+      <bibl><author>DE ROSA</author>, <title>Aurea epistola</title>, <pubPlace>Patavii</pubPlace>
+         <date>1759</date>, in 8. <note>Questa riguarda la Rosa d’oro, che i Papi solevano in certe
+            circostante mandare in dono alla Repubblica Veneta, delle quali le ultime a’ giorni
+            nostri si videro nel Tesoro di S. Marco.</note>
+      </bibl></item>
+   <item xml:id="c1d1e23527" n="1218">
+      <label>1218.</label>
+      <bibl><author>VANDELLI Domenico, sotto il nome di Paleofilo</author>, <title>Lettera sul vero
+            Rubicone degli antichi</title>, <date>1764</date>, in 4, M. 30. </bibl></item>
+   <item xml:id="c1d1e23552" n="1222" corresp="dcl:hnw">
+      <label>1222.</label>
+      <bibl><author>VISCONTI Ennio Quirino</author>, <title>Lettera su d’un antico piombo
+            Veliterno</title>, <pubPlace>Roma</pubPlace>
+         <date>1796</date>, in 4, M. 10 e 65. <note>Questa lettera fu dall’autore diretta al Card.
+            Borgia e su questa medesima medaglina di piombo scrisse nello stesso anno una
+            illustrazione anche l’Ab. Sestini e la diresse al Sig. Giorgio Zoega.</note>
+      </bibl></item>
+   <item xml:id="c1d1e23601" n="1229" corresp="dcl:mnt">
+      <label>1229.</label>
+      <bibl><author>VOLPI Giuseppe Rocco</author>, <title>Lettera al Sig. Ab. Giuseppe Finy intorno
+            a due antiche lapide scopertesi ultimamente in Cori</title>, <pubPlace>Roma</pubPlace>
+         <date>1733</date>, in 4, M. 58.</bibl></item>
+   <item xml:id="c1d1e23729" n="1247" corresp="dcl:dp3">
+      <label>1247.</label>
+      <bibl><title>DESCRIZIONE della pittura fatta nella volta della sala di Villa Pinciana</title>,
+            <pubPlace>Roma</pubPlace>
+         <date>1779</date>, in 4, M. 15. </bibl></item>
+   <item xml:id="c1d1e23802" n="1258">
+      <label>1258.</label>
+      <bibl><title>ELENCO degli oggetti di Belle Arti disposti nelle cinque sale apertesi
+            nell’Agosto del <date>1817</date> nella R. Accademia in Venezia</title>, M. 80.
+      </bibl></item>
+   <item xml:id="c1d1e23864" n="1267" corresp="dcl:2kn">
+      <label>1267.</label>
+      <bibl><author>GUILLON Abbé</author>, <title>Le Cénacle de Leonard de Vinci rendu aux amis des
+            beaux arts</title>, <pubPlace>Milan</pubPlace>
+         <date>1811</date>, en 8. </bibl></item>
+   <item xml:id="c1d1e23870" n="1268" corresp="dcl:6cp">
+      <label>1268.</label>
+      <bibl><title>ISTRUZIONE intorno alle opere de’ pittori nazionali ed esteri</title>, esposta in
+         pubblico nella città di Milano, con qualche notizia de’ scultori e architetti. Parte Prima,
+            <pubPlace>Milano</pubPlace>
+         <date>1777</date>, in 8. <note>Non ne fu mai pubblicato che questa prima sola parte.</note>
+      </bibl></item>
+   <item xml:id="c1d1e23889" n="1271">
+      <label>1271.</label>
+      <bibl><author>MELLINI Domenico</author>, <title>Ricordi intorno ai costumi azioni e governo
+            del Serenissimo Gran Duca Cosimo Primo, scritti di commissione della Sereniss. Maria
+            Cristina di Lorena, ora per la prima volta pubblicati con illustrazioni</title>,
+            <pubPlace>Firenze</pubPlace>
+         <date>1820</date>, in 8, M. 80. <note>Il Canonico Moreni pubblicò questi scritti e ne
+            intitolò al Vermiglioli l’edizione. Si parla in questi di molti artisti di quell’età e
+            delle loro opere ed altri aneddoti relativi alle arti.</note>
+         <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+      </bibl></item>
+   <item xml:id="c1d1e23901" n="1272" corresp="dcl:9zq">
+      <label>1272.</label>
+      <bibl><title>MEMORIE intorno l’antichissima scuola della Madonna dei Mascoli eretta nella
+            Basilica di S. Marco</title>, <pubPlace>Venezia</pubPlace>
+         <date>1791</date>, in 8, M. 80. <note>Avanti il frontespizio sta mal disegnato e peggio
+            inciso l’altare della cappella dei Mascoli</note>
+      </bibl></item>
+   <item xml:id="c1d1e23907" n="1273" corresp="dcl:nvn">
+      <label>1273.</label>
+      <bibl><title>MUSIVORUM quae Bergomi in comitis equitis Antonii Moroni redibus asservantur
+            historica descriptio</title>, <date>1791</date>, in 4, m. 10. <pb type="cico" n="222"/>
+      </bibl></item>
+   <item xml:id="c1d1e23979" n="1283">
+      <label>1283.</label>
+      <bibl><author>TARGIONI Tozzetti Antonio</author>, <title>Rapporto delle adunanze tenute nella
+            Terza Classe dell’Accademia di Belle Arti e dei perfezionamenti delle manifatture in
+            Toscana</title>, <pubPlace>Firenze</pubPlace>
+         <date>1818</date>, in 8, M. 80. </bibl></item>
+   <item xml:id="c1d1e24033" n="1290" corresp="dcl:nzc dcl:tjn">
+      <label>1290.</label>
+      <bibl><title>ALMANAC de Beaux arts pour l’an XII et l’an XIII. de la Repub. Français</title>,
+         2 vol. in 12, <pubPlace>Paris</pubPlace>. <note>In questi due anni 1803 e 1804 escì questo
+            almanacco e forse alcuni anni dopo ebbe continuazione. Leggermente li passano in rivista
+            infiniti oggetti d’arte e nomi d’artisti e opere esche ec. Simili opere sono buone come
+            repertorio.</note>
+      </bibl></item>
+   <item xml:id="c1d1e24045" n="1292">
+      <label>1292.</label>
+      <bibl><author>AMORINI Antonio</author>, <title>Discorso letto nella grand’Aula della
+            Pontificia Accademia di Belle Arti in Bologna l’anno <date>1816</date></title>, in 8.
+      </bibl></item>
+   <item xml:id="c1d1e24051" n="1293">
+      <label>1293.</label>
+      <bibl><title>ANTOLOGIA romana</title>, Giornale che include tutto ciò che ha relazione colle
+         produzioni delle <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/> arti; stampato in <pubPlace>Roma</pubPlace>, vol. 24, in 4. Questa
+         collezione ha il suo principio dal <date>1774</date> e termina al <date>1797</date>.
+            <note>Tutte quest’opere periodiche sulle arti stampate in Roma sono difficili a
+            riunirsi. Le principali sono l’antologia, le Effemeridi Letterarie, il Giornale di
+            Manlio, le Memorie per le Belle Arti, i monumenti inediti antichi di Guattani e le
+            Memorie Enciclopediche dello stesso: vi si possono aggiungere le Orazioni Accademiche di
+            Campidoglio. Questa numerosa raccolta di volumi forma il complesso più ampio e più
+            interessante.</note>
+      </bibl></item>
+   <item xml:id="c1d1e24063" n="1294">
+      <label>1294.</label>
+      <bibl><author>ARFELLI Angelo</author>, <title>Orazione per la distribuzione dei premi di Belle
+            Arti nell’istituto di Bologna</title>, l’anno <date>1736</date>, in 4. </bibl></item>
+   <item xml:id="c1d1e24078" n="1296">
+      <label>1296.</label>
+      <bibl><author>BALDI Giuseppe</author>, <title>Orazione in lode delle tre arti in occasione
+            della distribuzione dei premi nell’Istituto di Bologna</title>, l’a. <date>1780</date>,
+         in 8. </bibl></item>
+   <item xml:id="c1d1e24084" n="1297">
+      <label>1297.</label>
+      <bibl><author>BARUFFALDI Girolamo</author>, <title>Il premio delle Belle Arti distribuito
+            nell’Accademia Clementina in Bologna</title>, l’anno <date>1729</date>, in 4.
+      </bibl></item>
+   <item xml:id="c1d1e24108" n="1301">
+      <label>1301.</label>
+      <bibl><author>BOSSI Luigi</author>, <title>Della erudizione degli artisti: Discorso</title>,
+            <pubPlace>Padova</pubPlace>
+         <date>1810</date>, in 8, M. 36. </bibl></item>
+   <item xml:id="c1d1e24121" n="1303" corresp="dcl:1s6">
+      <label>1303.</label>
+      <bibl><author>CALURA Bernardino M.</author>, <title>In onore delle Belle Arti abbozzi di
+            laudazione delineati</title>, <pubPlace>Venezia</pubPlace>
+         <date>1814</date>, in 8. </bibl></item>
+   <item xml:id="c1d1e24127" n="1304">
+      <label>1304.</label>
+      <bibl><author>CALVI Jacopo</author>, <title>Discorso letto nella R. Accademia di Belle
+            Arti</title>, <pubPlace>Bologna</pubPlace> l’anno <date>1808</date>, in 8.
+      </bibl></item>
+   <item xml:id="c1d1e24139" n="1306">
+      <label>1306.</label>
+      <bibl><author>CIAMPI Sebastiano</author>, <title>Statuti dell’opera di S. Jacopo di Pistoia
+            volgarizzati l’anno 1313 da Masseo di ser Giovanni Bellebuoni</title>,
+            <pubPlace>Pisa</pubPlace>
+         <date>1815</date>, M. 26. </bibl></item>
+   <item xml:id="c1d1e24176" n="1311">
+      <label>1311.</label>
+      <bibl><title>EFFEMERIDI letterarie di Roma</title>, giornale che include fra le sue materie
+         tutto ciò che ha relazione collo studio delle arti. Stampato in <pubPlace>Roma</pubPlace>,
+         vol. 28, in 8. <note>Ha il suo principio dal 1772 al 1798. Con un volume addizionale del
+            1806, in 4.</note>
+      </bibl></item>
+   <item xml:id="c1d1e24182" n="1312">
+      <label>1312.</label>
+      <bibl><author>FABRI Alessandro</author>, <title>Orazione per la distribuzione de’ premi alle
+            Belle Arti nell’istituto di Bologna</title>, l’anno <date>1782</date>, in 4.
+      </bibl></item>
+   <item xml:id="c1d1e24188" n="1313" corresp="dcl:s81">
+      <label>1313.</label>
+      <bibl><author>FEA Carlo</author>, <title>Discorso intorno alle Belle Arti in Roma</title>,
+         recitato nell’Adunanza degli Arcadi, <pubPlace>Roma</pubPlace>
+         <date>1797</date>, in 8. </bibl></item>
+   <item xml:id="c1d1e24201" n="1315">
+      <label>1315.</label>
+      <bibl><title>FONDATION de l’Académie Royale Danoise de Peinture, Sculpture, Architecture,
+            établie à Copenaghue</title>, <pubPlace>Copenaghue</pubPlace>
+         <date>1764</date>, in 4. </bibl></item>
+   <item xml:id="c1d1e24207" n="1316">
+      <label>1316.</label>
+      <bibl><title>FONDATION renouvellée pour l’Académie Royale des beaux arts à Copenhague</title>,
+            <pubPlace>Odensé</pubPlace>
+         <date>1814</date>, in 8. <note>Questi statuti ci vennero dati dallo stesso presidente
+            dell’accademia Cristiano Federico, Principe Reale.</note>
+      </bibl></item>
+   <item xml:id="c1d1e24213" n="1317" corresp="dcl:303">
+      <label>1317.</label>
+      <bibl><author>FOSSATI Giuseppe Luigi</author>. <title>Memoria sopra due cele <pb type="cico"
+               n="227"/> bri accademie veneziane</title>, <pubPlace>Venezia</pubPlace>
+         <date>1806</date>, in ottav. <note>Le due accademie sono l’Aldina e la Veneziana, detta
+            altrimenti della Fama.</note>
+      </bibl></item>
+   <item xml:id="c1d1e24225" n="1319">
+      <label>1319.</label>
+      <bibl><author>FOSSATI</author>, <title>Orazione recitata nella pubblica Veneta Accademia di
+            Belle Arti per la distribuzione de’ premi dell’anno <date>1776</date></title>, in 8.
+      </bibl></item>
+   <item xml:id="c1d1e24275" n="1326">
+      <label>1326.</label>
+      <bibl><author>MACHIAVELLI Alessandro</author>, <title>Orazione in occasione de’ premi
+            distribuiti alle Belle Arti nell’istituto di Bologna l’anno <date>1735</date></title>,
+         in 4. </bibl></item>
+   <item xml:id="c1d1e24281" n="1327" corresp="dcl:dk0 dcl:v7w">
+      <label>1327.</label>
+      <bibl><author>MAGNANI Antonii</author>, <title>Orationes habitae in pubblico archigymnasio
+            bononiensi</title>, <pubPlace>Parma</pubPlace>
+         <date>1794</date>, in fol. <note>Sono queste due orazioni latine ed una italiana in
+            occasione della distribuzione dei premi agli studiosi delle arti del disegno,
+            elegantemente pubblicate coi tipi bodoniani. La prima però verte sulle lodi di Francesco
+            M. Zanotti.</note>
+      </bibl></item>
+   <item xml:id="c1d1e24287" n="1328">
+      <label>1328.</label>
+      <bibl><author>MALLIO Michele</author>, <title>Annali di Roma dal <date>1790 al
+            1796</date></title>, vol. 18, in 8. <note>Contengono questi un giornale periodico
+            letterario in cui <pb type="cico" n="228"/> rendesi conto delle principali opere d’arte
+            uscite in quell’epoca.</note>
+      </bibl></item>
+   <item xml:id="c1d1e24305" n="1331">
+      <label>1331.</label>
+      <bibl><author>MENZINI Giovan Battista</author>, <title>Le Grazie rivali, declamazioni
+            accademiche</title>, <pubPlace>Bologna</pubPlace>
+         <date>1637</date>, in 12. </bibl></item>
+   <item xml:id="c1d1e24312" n="1332">
+      <label>1332.</label>
+      <bibl><author>MIGNANI Giovan Battista</author>, <title>Orazione in occasione del premio alle
+            Belle Arti nell’istituto di Bologna l’anno <date>1733</date></title>, in 4.
+      </bibl></item>
+   <item xml:id="c1d1e24324" n="1334" corresp="dcl:9gb">
+      <label>1334.</label>
+      <bibl><author>NICCOLINI Giovan Battista</author>, <title>Orazione per la distribuzione dei
+            premi nel solenne concorso triennale dell’Accademia di Belle Arti in Firenze</title>,
+            <date>1809</date>, in 4, M. 25. </bibl></item>
+   <item xml:id="c1d1e24330" n="1335">
+      <label>1335.</label>
+      <bibl><title>NOTICIA historica de los principios y progressos de la scuola gratuita de las
+            nobles Artes erigida en Barcelona</title>, <pubPlace>Barcelona</pubPlace>
+         <date>1789</date>, in 4. </bibl></item>
+   <item xml:id="c1d1e24336" n="1336" corresp="dcl:qg6">
+      <label>1336.</label>
+      <bibl><title>NOTIZIE dell’origine e progressi dell’Istituto delle Scienze in Bologna, e sue
+            Accademie</title>: <pubPlace>Bologna</pubPlace>
+         <date>1780</date>, in 8. <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+      </bibl></item>
+   <item xml:id="c1d1e24367" n="1340">
+      <label>1340.</label>
+      <bibl><author>PETRACCHI Celestino</author>, <title>Orazione per la distribuzione del premio
+            alle Belle Arti nell’Accademia Clementina di Bologna</title>, l’ a. <date>1737</date> in
+         4. </bibl></item>
+   <item xml:id="c1d1e24472" n="1356">
+      <label>1356.</label>
+      <bibl><title>SAGGI accademici dati in Roma nell’Accademia del Principe Cardinale di Savoia
+            pubblicati da Monsig. Agostino Mascardi</title>, <pubPlace>Venezia</pubPlace>
+         <date>1630</date>, in 4. </bibl></item>
+   <item xml:id="c1d1e24502" n="1361">
+      <label>1361.</label>
+      <bibl><author>SCARSELLI Flaminio</author>, <title>Orazione per la distribuzione del premio
+            alle Belle Arti nell’Accademia Clementina di Bologna</title>, l’anno <date>1731</date>,
+         in 8. <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+      </bibl></item>
+   <item xml:id="c1d1e24567" n="1368">
+      <label>1368.</label>
+      <bibl><author>ROSMINI Carlo</author>, <title>Quattro opuscoli inediti del secolo XVI
+            pubblicati in occasione degli Eccelsi Sponsali Trivulzio in Archinti</title>,
+            <pubPlace>Milano</pubPlace>
+         <date>1819</date>, in 8. <note>Questi sono l’entrata solenne in Parigi di Maria sorella del
+            re d’Inghilterra quale sposa di Luigi XII incoronata al 4 Novembre 1514. Il Funerale di
+            Luigi XII nel 1 Gen. 1515. L’entrata in Parigi di Francesco I a 15 Febbraro 1515. Una
+            lettera scritta dal segretario dei quattro oratori della R Veneziana spediti a Milano
+            per onorare in quell’anno il re di Francia.</note> MDXXXV </bibl>
+   </item>
+   <item xml:id="c1d1e24612" n="1374">
+      <label>1374.</label>
+      <bibl><author>MORETTO da Lucca</author>, <title>La superba, ricca, pomposa, et magnifica
+            creazione, che ha fatto l’Illustrissimo et Eccell. Duca di Ferrara</title>. Festa
+         descritta dal Moretto da Lucca alla Sig. D. Lucrezia Estense Medici Duchessa di Ferrara,
+            <pubPlace>Ferrara</pubPlace>
+         <date>1559</date>, in 8. <note>Le descrizioni di questa festa sono un curioso misto di
+            narrative e di poeti.</note> MDLXV </bibl></item>
+   <item xml:id="c1d1e24636" n="1378">
+      <label>1378.</label>
+      <bibl><author>MELLINI Domenico</author>, <title>Descrizione dell’apparato della commedia ed
+            intermedi d’essa</title>, recitata in Firenze il giorno di S. Stefano l’anno 1563 per le
+         Nozze di D. Francesco Medici e della Regina Giovanna d’Austria,
+            <pubPlace>Firenze</pubPlace>, <publisher>Giunti</publisher>, <date>1566</date>, in 8.
+         Aggiuntavi la <title>descrizione dell’entrata della Regina Giovanna d’Austria e
+            dell’apparato</title>, scritta da <author>Domenico Mellini</author>,
+            <pubPlace>Firenze</pubPlace>, <publisher>Giunti</publisher>, anno suddetto. <note>È
+            indicato in fine di questo prezioso libretto come D. Vincenzo Borghini inventò
+            l’apparato e segue nominando tutti i chiarissimi uomini di lettere e d’arti che vi
+            furono impiegati.</note> MDLXVIII </bibl></item>
+   <item xml:id="c1d1e24643" n="1379">
+      <label>1379.</label>
+      <bibl><title>RAGIONAMENTO sopra le pompe della città di Bologna</title>, nel quale si discorre
+         sopra le feste, i banchetti, i corsi pubblici di detta città, <pubPlace>Bologna</pubPlace>
+         <date>1568</date>, in 4. <note>Questo riguarda alcune disposizioni suntuarie ed è ripieno
+            di una quantità di curiose nozioni.</note> MDLXVIII </bibl></item>
+   <item xml:id="c1d1e24790" n="1400">
+      <label>1400.</label>
+      <bibl><title>DESCRIPTIO et explicatio pegmatum, arcuum et spectaculorum qua Bruxellae prid.
+            Kal. Feb. 1593 exhibita fuere sub ingressum Seren. Prin. Ernesti Archid. Austriae, pro
+            Phil. II. Hispaniarum Monarcha Belgicae ditionis gubernatore</title>,
+            <pubPlace>Brux.</pubPlace>
+         <date>1594</date>, in fol. fig. <note>Con 22 tavole in rame.</note> MDXCV </bibl></item>
+   <item xml:id="c1d1e24809" n="1403">
+      <label>1403.</label>
+      <bibl><title>LA FELICISSIMA ENTRATA della Sereniss. Regina di Spagna Donna Margarita d’Austria
+            nella città di Ferrara nel 1598 avuta dal Cav. Reale</title>, in <pubPlace>Ferrara e in
+            Bologna</pubPlace>
+         <date>1698</date>, in 4. <note>Sono due foglietti di stampa.</note> MDXCVIII </bibl></item>
+   <item xml:id="c1d1e24835" n="1406">
+      <label>1406.</label>
+      <bibl><author>BUONARROTI Michel Angelo</author>, <title>Descrizione delle felicissime nozze di
+            Madama Maria Medici Regina di Francia e di Navarra</title>, <pubPlace>Firenze</pubPlace>
+         <date>1600</date>, in 8. MDC </bibl></item>
+   <item xml:id="c1d1e24866" n="1411" corresp="dcl:45t">
+      <label>1411.</label>
+      <bibl><author>ZUCCARI Federico</author>, <title>li passaggio per l’Italia e la dimora in Parma
+            del cav. Federico Zuccari in occasione delle feste date al P. Francesco Gonzaga e
+            all’infanta Margarita di Savoia</title>. Opuscoli due, in 4. Rarissimi.
+            <pubPlace>Bologna</pubPlace>
+         <date>1608</date>. <pb type="cico" n="241"/> MDCVIII <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+      </bibl></item>
+   <item xml:id="c1d1e24880" n="1412">
+      <label>1412.</label>
+      <bibl><title>DESCRIZIONE delle feste fatte nelle reali nozze dei Serenissimi Principi di
+            Toscana, D. Cosimo de’ Medici e Maria Maddalena Arciduchessa d’Austria</title>,
+            <pubPlace>Firenze</pubPlace>, presso <publisher>i Giunti</publisher>, <date>1508</date>,
+         in 8. <note>Questo è uno degli opuscoli di esecuzione diligentissima e ricchissimo di
+            cognizioni in questa materia. Vedi per le tavole all’articolo Stradano Equile.</note>
+         MDCX </bibl></item>
+   <item xml:id="c1d1e24925" n="1419">
+      <label>1419.</label>
+      <bibl><title>BREVE Descrizione della festa fatta nella gran Sala del Podestà di Bologna l’anno
+               <date>1615</date></title>, dedicata al Sig. Giulio Strozzi da <publisher>Vittorio
+            Benacci</publisher> stampatore in <pubPlace>Bologna</pubPlace>, in 8. MDCXV
+      </bibl></item>
+   <item xml:id="c1d1e24931" n="1420" corresp="dcl:d8d">
+      <label>1420.</label>
+      <bibl><title>DESCRIZIONE dell’arrivo d’Amore in Toscana in grazia delle bellissime dame
+            fiorentine</title>, <pubPlace>Firenze</pubPlace>
+         <date>1615</date>, in 8. <note>Sono due foglietti di stampa.</note>
+         <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/> MDCXVI </bibl></item>
+   <item xml:id="c1d1e24944" n="1421">
+      <label>1421.</label>
+      <bibl><author>SALVADORI Andrea</author>, <title>Guerra di bellezza</title>. Festa a cavallo
+         fatta a Firenze per la venuta del Serenissimo Principe d’Urbino,
+            <pubPlace>Firenze</pubPlace>
+         <date>1616</date>, in 8. <note>L’invenzione e le poesie furono di Andrea Salvadori.</note>
+         MDCXVI </bibl></item>
+   <item xml:id="c1d1e25036" n="1435" corresp="dcl:bp6">
+      <label>1435.</label>
+      <bibl><author>PUTEANI Fran.</author>, <title>Pompa Funebris Optimi potentissimi Principis
+            Alberti Pii Arch. Austriae Ducis Bar. Braban. veris imaginibus expressa a Sac. Fran.
+            Francquart, Arch. Reg. eiusdem Principis morientis vita a Fran. Puteano</title>,
+            <pubPlace>Bruxelles</pubPlace>
+         <date>1628</date>, in fol., 66 tavole. MDCXXVIII </bibl></item>
+   <item xml:id="c1d1e25134" n="1449">
+      <label>1449.</label>
+      <bibl><author>GRIGNANI Lod.</author>, <title>Relazione delle esequie fatte in S. Alessio al
+            Cardinal di Bagno descritta da Ludovico Grignani stampatore</title>,
+            <pubPlace>Roma</pubPlace>
+         <date>1641</date>, in 4. <pb type="cico" n="248"/> MDCXLIV </bibl></item>
+   <item xml:id="c1d1e25228" n="1462">
+      <label>1462.</label>
+      <bibl><title>FUNERALI di Giacomo III, re della Gran Bretagna celebrati per ordine dii Clemente
+            VIII</title>, l’anno <date>1666</date>
+         <pubPlace>Roma</pubPlace>, in fol. fig. MDCLXVI </bibl></item>
+   <item xml:id="c1d1e25247" n="1465">
+      <label>1465.</label>
+      <bibl><title>DIMOSTRAZIONI festive fattesi in Parma da Ranuccio Farnese per l’assunzione al
+            pontificato di Clemente IX</title>, <pubPlace>Parma</pubPlace>
+         <date>1667</date>, in fol. pic. <note>Con una sola piccola tavola in rame.</note>
+         <pb type="cico" n="251"/> MDCLXVII </bibl></item>
+   <item xml:id="c1d1e25304" n="1473" corresp="dcl:zz7">
+      <label>1473.</label>
+      <bibl><title>DISEGNO della mascherata fatta in Lodi</title>, il carnevale del
+            <date>1680</date> per le nozze di Carlo II re di Spagna, <pubPlace>Milano</pubPlace>, in
+         8, fig. <note>Vi sono undici stampe disegnate ed incise da Filippo Biffi con poca
+            fortuna.</note> MDCLXXX </bibl></item>
+   <item xml:id="c1d1e25360" n="1481" corresp="dcl:98f">
+      <label>1481.</label>
+      <bibl><title>ARCOS triumphalis Leopoldo Magno, Eleonorae Augustae, Josepho glorioso a Senatu
+            pupuloque Viennensi positus et emblematibus ornatus anno <date>1690</date></title>, in
+         fol. fig. <note>Le invenzioni e disegni di cattivo gusto in mezzo a molta magnificenza sono
+            di Bernardo Fischer, intagliate da Denuer. Le tavole degli apparati ed arco sono due in
+            foglio atlantico e 16 le tavole degli emblemi.</note>
+         <pb type="cico" n="254"/> MDCXC </bibl></item>
+   <item xml:id="c1d1e25368" n="1482">
+      <label>1482.</label>
+      <bibl><author>Aimi A D. Vincenzo</author>, <title>La giostra discorso historico</title>,
+            <pubPlace>Palermo</pubPlace>
+         <date>1690</date>, in 8. <note>Opuscoletto erudito con una tavola.</note> MDCXCI
+      </bibl></item>
+   <item xml:id="c1d1e25392" n="1485" corresp="dcl:v28">
+      <label>1485.</label>
+      <bibl><title>BREVE descrizione e disegni delle carrozze dell’Eccellentissimo Signor Antonio
+            Floriano del S. R. I. Principe di Liechtenstein ambasciatore alla Sede Apostolica
+            dedicata al Card. di Goes</title>, <pubPlace>Roma</pubPlace>, per <publisher>Giacomo
+            Komarck</publisher>, <date>1694</date>, in fol. <note>Sonovi dodici curiose e
+            interessantissime tavole che rappresentano le carrozze di gala di quei tempi disegnate
+            da Antonio Cresolini e incise accuratamente da Huberto Vincenti.</note> MDCCII
+      </bibl></item>
+   <item xml:id="c1d1e25443" n="1492">
+      <label>1492.</label>
+      <bibl><title>INGRESSO in Dresda delle deità pagane</title>, <pubPlace>Augusta</pubPlace>, per
+            <publisher>Geremia Wolff</publisher>, <date>1718</date>, in fol. obl., in tedesco.
+            <note>Sono queste espresse in 10 tavole di doppio foglio precedute da tei pagine di
+            testo compreso il frontespizio.</note> MDCCXX </bibl></item>
+   <item xml:id="c1d1e25450" n="1493">
+      <label>1493.</label>
+      <bibl><title>DESCRIZIONE del cambio degli ambasciatori dell’Imperatore de’ Romani con quelli
+            della Porta Ottomana accaduto in Belgrado li 20 Aprile <date>1720</date></title>, in
+         lingua tedesca in fol. obl. <note>Geremia Wolff d’Augusta intagliò tutte le tavole che sono
+            di doppio foglio ed anche la prima tutta in caratteri, le quali sono in tutte 18.</note>
+         MDCCXXIV </bibl></item>
+   <item xml:id="c1d1e25456" n="1494">
+      <label>1494.</label>
+      <bibl><title>RELAZIONE della funzione eseguita dal Marchese di Pescara delegato a dare
+            l’ordine del Toson d’oro al Gran Contestabile D. Fabrizio Colonna</title>,
+            <pubPlace>Roma</pubPlace>
+         <date>1724</date>, in fogl. pic. MDCCXXV </bibl></item>
+   <item xml:id="c1d1e25480" n="1498" corresp="dcl:cp0">
+      <label>1498.</label>
+      <bibl><author>BERNI Francesco</author>, <title>Il Torneo a piedi</title> e l’invenzione ed
+         allegoria colla quale il Sig, Dorso Bonacossi comparì a sostenerlo e l’Alcina maga, favola
+         Pescatoria, rappresentata nella sala dei Giganti in <pubPlace>Ferrara</pubPlace>, nel
+         Carnevale del <date>1731</date>, in 8. MDCCXXXII </bibl></item>
+   <item xml:id="c1d1e25505" n="1501">
+      <label>1501.</label>
+      <bibl><title>ESEQUIE di Maria Sobieski Regina d’Inghilterra celebrate in Fano</title>, fol.
+         fig., <pubPlace>Fano</pubPlace>
+         <date>1735</date>. <note>Descritta da Sebastiano Paoli, con due grandissime tavole in
+            rame.</note> MDCCXXXVI </bibl></item>
+   <item xml:id="c1d1e25517" n="1503">
+      <label>1503.</label>
+      <bibl><title>SOLENNI esequie celebrate in Milano i 12 decembre 1736 nella Chiesa di San Fedele
+            per la morte del Mar. D. Giorgio Clerici</title>, <pubPlace>Milano</pubPlace>
+         <date>1736</date>, in fol. figurato. <note>Sonovi sei grandissime tavole di mediocre
+            esecuzione. <pb type="cico" n="258"/> L’architetto fu Francesco Croce. L’intagliatore
+            Gaetano Bianchi.</note> MDCCXXXVII </bibl></item>
+   <item xml:id="c1d1e25554" n="1508">
+      <label>1508.</label>
+      <bibl><title>RELAZIONE dei solenni funerali celebrati in Napoli alla memoria di Clemente XII
+            nel Marzo <date>1740</date></title>, in foglio. <note>L’orazion funerale che sta in fine
+            è del canonico Sirammaco Mazocchi.</note>
+         <pb type="cico" n="259"/> MDCCXLII </bibl></item>
+   <item xml:id="c1d1e25562" n="1509">
+      <label>1509.</label>
+      <bibl><title>DICHIARAZIONE del solenne apparato fatto nella chiesa del Carmine in Pavià nella
+            morte del Sig. Conte D. Giuseppe Scaramuzza Visconti</title>,
+            <pubPlace>Milano</pubPlace>
+         <date>1742</date>, in fol. p. fig. <note>Sono tre grandissime e mal eseguite tavole in gran
+            forme.</note> MDCCXLII </bibl></item>
+   <item xml:id="c1d1e25587" n="1513" corresp="dcl:k59">
+      <label>1513.</label>
+      <bibl><title>ESEQUIE reali per la morie dell’Augusto re cattolico delle Spagne Filippo V,
+            Borbone solennemente celebrate nella metropolitana chiesa di Palermo</title>,
+            <pubPlace>Palermo</pubPlace>
+         <date>1747</date>, in fol. fig. <note>Con due gran tavole in rame e l’orazione funerale in
+            fine scritta da Vincenzo Pupella.</note>
+         <pb type="cico" n="260"/> MDCCXLIX </bibl></item>
+   <item xml:id="c1d1e25595" n="1514">
+      <label>1514.</label>
+      <bibl><author>DALLE LASTE Natale</author>, <title>Lettera inedita e MS. che descrive le feste
+            date in Casa Foscarini alli Carmini in Venezia alla Corte di Modena</title>, nell’Agosto
+            <date>1749</date>. <note>Questo letterato insieme al Forcellini furono spettatori di
+            quelle feste e la descrizione si estende con infinita grazia anche sulle cose le più
+            minute.</note> MDCCXLIX <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+      </bibl></item>
+   <item xml:id="c1d1e25607" n="1515">
+      <label>1515.</label>
+      <bibl><title>NARRAZIONE delle solenni reali feste celebrate in Napoli da Carlo Infante di
+            Spagna per la nascita del suo primogenito Filippo Real Principe delle due
+            Sicilie</title>, <pubPlace>Napoli</pubPlace>
+         <date>1749</date>, in fot. atl. fig. <note>Con 14 tavole grandissime intagliate da Gius.
+            Vasi, da Luigi le Lorain, da Jardin ec. il tutto d’invenzione dell’architetto Vincenzo
+            Re. Esemplare di dedica.</note> MDCCL </bibl></item>
+   <item xml:id="c1d1e25613" n="1516">
+      <label>1516.</label>
+      <bibl><author>BARTOLI Gius.</author>, <title>La vittoria d’Imeneo, festa rappresentata in
+            Torino per le nozze di Vittorio Amedeo Duca di Savoia e Maria Antonia Ferdinanda di
+            Spagna</title>, <pubPlace>Torino</pubPlace>
+         <date>1750</date>, in 4, fig. <note>I tre disegni furono dei fratelli Gagliarri intagliati
+            con gusto da Le-Bas: e la descrizione di Giuseppe Bartoli.</note> MDCCLI </bibl></item>
+   <item xml:id="c1d1e25620" n="1517">
+      <label>1517.</label>
+      <bibl><title>ELISAE. Christinas Augusta Maria Theresae Augustse Matri justa funebria</title>,
+            <pubPlace>Mediolani</pubPlace>
+         <date>1751</date>, in fol. fig. <note>Otto intagli ornano l’edizione scolpiti da Giacomo
+            Mercori e lo scrittore dell’orazion funebre in fine è il Conte Paolo Caroello.</note>
+         MDCCXLI </bibl></item>
+   <item xml:id="c1d1e25632" n="1519">
+      <label>1519.</label>
+      <bibl><author>SCAMOZZI Ottav.</author>, <title>Descrizione dell’arco trionfale fatto in
+            Vicenza per l’esaltazione al Cardinalato <pb type="cico" n="261"/> del Vescovo Antonio
+            Marino Priuli</title>, <pubPlace>Vicenza</pubPlace>
+         <date>1758</date>, in 4, fig. <note>La descrizione e invenzione tono di Ottavio Bertoni
+            Scamozzi, con quattro tavole.</note> MDCCLX </bibl></item>
+   <item xml:id="c1d1e25638" n="1520" corresp="dcl:fw0">
+      <label>1520.</label>
+      <bibl><title>RELACION de las exequias que a la magestad del rey catolico D. Fernando VI, se
+            hicieron en la Real Iglesia de Santiago de los Espanuoles de Roma</title>,
+            <pubPlace>Roma</pubPlace>
+         <date>1760</date>, in fol. fig. <note>Le due tavole in fol. atlantico furono disegnate dal
+            Passarini.</note> MDCCLXIV </bibl></item>
+   <item xml:id="c1d1e25644" n="1521" corresp="dcl:p37">
+      <label>1521.</label>
+      <bibl><title>DISEGNI della macchina e peote ordinate in occasione della regata in onore del
+            Principe Re d’Inghilterra Odoardo Augusto Duca di Yorck l’anno <date>1764</date>, li 4
+            Giugno</title>. <note>Giorgio Fossati fu il pittore prospettico. Francesco Zanchi operò
+            alle macchine e i Mauri pittori inventarono le peote. Le tavole sono cinque in foglio
+            doppio.</note> MDCCLXVI </bibl></item>
+   <item xml:id="c1d1e25669" n="1524" corresp="dcl:2zz dcl:7zs">
+      <label>1524.</label>
+      <bibl><title>DESCRITION du Jubilé de sept cens ans de S.Macaire celebre dans la ville de
+            Gand</title>, enrichie de figures, <pubPlace>Gand</pubPlace>
+         <date>1767</date>, in 4. <note>Questo libro è stravagante, poiché in onore di questo santo
+            protettore contro la pestilenza si dà conto degli spettacoli di questo Giubileo
+            consistenti in processioni, cavalcate, trion <pb type="cico" n="262"/> fi, mascherate,
+            opere, commedie, balli, fuochi ed altri esercizi; contiene quindici grandi tavole
+            intagliate in rame.</note> MDCCLXIX </bibl></item>
+   <item xml:id="c1d1e25687" n="1527" corresp="dcl:bgb">
+      <label>1527.</label>
+      <bibl><title>EPITHALIMIA exoticis linguis reddita</title>, <pubPlace>Parmae</pubPlace>, ex
+            <publisher>Regio Tipographeo</publisher>, <date>1775</date>, in fol. fig. <note>G.
+            Volpato ed altri valenti intagliatori eseguirono le stampe ai capi pagina di quest’opera
+            che fu la prima a stabilire il sommo credito di Giovan Battista Bodoni: 25 sono i
+            diversi caratteri delle iscrizioni accompagnate dalla versione latina. L’opera è
+            preceduta da un’eruditissima dissertazione dell’Avv. Giovan Bernardo de’ Rossi e da un
+            avviso al lettore dell’insigne tipografo. In fine è un poemetto epitalamico del C.
+            Rezzonico della Torre e l’occasione in cui comparve quest’opera fu il matrimonio di
+            Carlo Emanuelle di Savoia con la sorella di Luigi XVI.</note> MDCCLXXXI </bibl></item>
+   <item xml:id="c1d1e25763" n="1538" corresp="dcl:p2b">
+      <label>1538.</label>
+      <bibl><title>DESCRIZIONE della festa celebrata in Venezia il giorno 15 Agosto
+               <date>1811</date> per l’inaugurazione della statua colossale di Napoleone</title>,
+            <pubPlace>Venezia</pubPlace>, in 8. MDCCCXIII </bibl></item>
+   <item xml:id="c1d1e25769" n="1539" corresp="dcl:q8b">
+      <label>1539.</label>
+      <bibl><author>CLARAC</author>, <title>Fouille faite à Pompeii en présence de la Reine des deux
+            Siciles le 18 Mais <date>1813</date>, etc.</title>, <pubPlace>Napoli</pubPlace>, in 8,
+         fig. <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/> MDCCCXIV </bibl></item>
+   <item xml:id="c1d1e25788" n="1541" corresp="dcl:wbt">
+      <label>1541.</label>
+      <bibl><title>DESCRIZIONE della festa drammatica offerta nella gran sala della ragione a
+            Francesco I e Maria Lodovica dalla città regia di Padova <date>1816</date></title>, in
+         foglio figurato. <note>Vi sono due tavole che rappresentano le nuove decorazioni di quel
+            salone capace di più di 8000 persone.</note>
+         <pb type="cico" n="265"/> MDCCCXX </bibl></item>
+   <item xml:id="c1d1e25796" n="1542">
+      <label>1542.</label>
+      <bibl><author>CANCELLIERI Francesco</author>, <title>Notizie della venuta in Roma di Canuto II
+            e Cosimo I re di Danimarca negli anni 1027 e 1676</title>, <pubPlace>Roma</pubPlace>
+         <date>1820</date>, in 4. MDCCCXX </bibl></item>
+   <item xml:id="c1d1e25802" n="1543">
+      <label>1543.</label>
+      <bibl><author>MANIN Leonardo</author>, <title>Relazione delle feste e soggiorno di Federico IV
+            re di Danimarca in Venezia l’anno 1708 diretta in forma di lettera al C. Leopoldo
+            Cicognara in occasione del soggiorno fatto a Venezia dei principi reali di Danimarca
+            l’anno <date>1820</date></title>. Manoscritto inedito e prezioso per le minute
+         circostanze in esso espresse e con rara diligenza raccolte.</bibl></item>
+   <item xml:id="c1d1e25822" n="1544">
+      <label>1544.</label>
+      <table>
+         <row role="data" rows="1" cols="1">
+            <cell role="data" rows="1" cols="1">— <title>Facciate illuminate e fuochi d’artificio in
+                  Roma al palazzo Colonna in occasione che presentavansi i tributi dalla corte di
+                  Napoli, per la solennità di S. Pietro</title>.</cell>
+            <cell role="data" rows="1" cols="1">Tav. 28</cell>
+         </row>
+         <row role="data" rows="1" cols="1">
+            <cell role="data" rows="1" cols="1">— Archi di trionfo e cavalcate nel possesso dei
+               sommi pontefici.</cell>
+            <cell role="data" rows="1" cols="1">Tav. 16</cell>
+         </row>
+         <row role="data" rows="1" cols="1">
+            <cell role="data" rows="1" cols="1">— Catafalchi e processioni mortuarie di diversi
+               oontefici.</cell>
+            <cell role="data" rows="1" cols="1">Tav. 10</cell>
+         </row>
+         <row role="data" rows="1" cols="1">
+            <cell role="data" rows="1" cols="1">— Vedute di alcune ville e luoghi interni ed esterni
+               di Roma.</cell>
+            <cell role="data" rows="1" cols="1">Tav. 17</cell>
+         </row>
+         <row role="data" rows="1" cols="1">
+            <cell role="data" rows="1" cols="1">— Vedute di altre ville, macchine e giardini di
+               Francia.</cell>
+            <cell role="data" rows="1" cols="1">Tav. 19</cell>
+         </row>
+         <row role="data" rows="1" cols="1">
+            <cell role="data" rows="1" cols="1">— Altre varie feste civili e religiose e
+               funerali.</cell>
+            <cell role="data" rows="1" cols="1">Tav. 13</cell>
+         </row>
+         <row role="data" rows="1" cols="1">
+            <cell role="data" rows="1" cols="1"/>
+            <cell role="data" rows="1" cols="1">Tav. 103 fol.</cell>
+         </row>
+      </table>
+   </item>
+   <item xml:id="c1d1e25903" n="1545">
+      <label>1545.</label>
+      <table>
+         <row role="data" rows="1" cols="1">
+            <cell role="data" rows="1" cols="1">— <title>Vedute di città assediate con molte figure
+                  ed ornamenti intagliate la <pb type="cico" n="266"/> più parte da Agostino Corvino
+                  sui disegni di Paolo Deker</title>.</cell>
+            <cell role="data" rows="1" cols="1">Tav. 14</cell>
+         </row>
+
+         <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+         <row role="data" rows="1" cols="1">
+            <cell role="data" rows="1" cols="1"> — Trionfi, ingressi, pompe civili e miiitari, Feste
+               di tori in Spagna, accampamenti, cavalcate, supplici, abiure, teatri, prospetti e
+               illuminazioni in molti luoghi.</cell>
+            <cell role="data" rows="1" cols="1">40 Tav.</cell>
+         </row>
+         <row role="data" rows="1" cols="1">
+            <cell role="data" rows="1" cols="1"/>
+            <cell role="data" rows="1" cols="1">Tav. 54</cell>
+         </row>
+      </table> Fra le quali sono rimarcabili e rare le feste di Siena e di Firenze del 1633 e 1717 e
+      la flotta navale col Principe d’Orange intagliata da R. de Hooghe. Sono in questo volume
+      aggiunte altre 16 carte disegnate a mano di battaglie navali Venete ec. </item>
+   <item xml:id="c1d1e25954" n="1546">
+      <label>1546.</label> — <bibl><title>Volume con molte stampe fra le quali diversi ingressi e
+            funerali in S.Marco di Ven. per Francesco Viusdomini <date>1669</date></title>: Per la
+         Princip. Dorotea in <pubPlace>Parma</pubPlace>
+         <date>1750</date>: Monumento in S. Pietro a Roma di Cl. XI, del Doge Foscari a Venezia ed
+         altri convogli funebri e coronazioni di M. Teresa, con molte vedute italiane, spagnuole e
+         francesi, fra le quali 6 di Firenze, 6 di Berlino, 4 di Londra, 5 di Vienna, 8 di Parigi e
+         ville, 4 di Pietroburgo, 4 di Roterdam, 4 di Udine, 3 di Spagna, 3 di Roma: Una bellissima
+         veduta di Palmira incisa a Londra, 2 incendi di flotte ec.: Il bombardamento di Biserta
+         fatto da Veneziani, l’assedio di Gibilterra del 1782, i monti di basalto, il lago di Lecco,
+         la facciata moderna di S. Rocco a Venezia, una veduta di Mantova: Tre vedute di Copenhague,
+         della piazza di Jo. Ulrich Kraus: Piano del monte Berico a Vicenza, 2 vedute, piani e
+         spaccati di S. Giustina in Padova: Prospetto di dieci porti inglesi e varie carte di
+         fortificazione marittima, il volume contiene tav. 97.</bibl>
+   </item>
+   <item xml:id="c1d1e25971" n="1547">
+      <label>1547.</label> — <bibl>Volume con molte stampe. <title>Comincia con 28 spaccati e
+            prospetti di varii palazzi e chiese di Roma, 8 vedute di altri pesi d’Europa, 9 vedute
+            d’ingressi, prospetti, funerali e 15 depositi esistenti in Roma nelle varie Chiese e
+            singolarmente in S. Pietro colla rispettiva pianta</title>: per Domenico de’ Rossi: e
+         alcune altre carte di simil genere nel complessivo numero di tavole 77. </bibl></item>
+   <item xml:id="c1d1e25987" n="1548">
+      <label>1548.</label> — <bibl><title>Ritratti di Sommi Pontefici 11</title>: Monumenti
+         Sepolcrali dei medesimi 20: Monumento di M. Clementina R. d’Inghil. in S. Pietro di Roma 1:
+         Ritratti di dogi veneti procuratori e altri sommi personaggi della R. Veneta intagliati da
+         Pitteri, Ciaconi, Volpato, Bartolozzi ed altri incisori in diverse dimensioni, fra quali
+         tre in foglio atlantico stampati in Pergamena, 54: Monumenti a Dogi e altri insigni veneti
+         personaggi 18: ingressi, feste pubbliche e private, spettacoli, caccie del toro, regate per
+         principi e personaggi ec. 32: Prospetti e spaccati della Cattedrale di Brescia 4; Consiglio
+         Patriarcale in Udine, facciata di S. Rocco a Venezia, prospetto delle 7 chiese in
+         Monselice, consecrazione della chiesa della Salute in Venezia, paliotto d’argento dorato
+         innanzi l’altar maggiore in S. Marco 5: in tutto il volume stampe 145.</bibl></item>
+   <item xml:id="c1d1e26018" n="1549">
+      <label>1549.</label>
+      <bibl><author>A. D.</author>
+         <title>Les divers portraicts et figures faictes sur les moeurs des habitans du nouveau
+            monde dedié à Jean le Roy Escuyer Sieur de la Boissiere gentilhomme Poictevin cherisseur
+            des Muses</title>, M. 105. <note>Sono 13 piccola stampe oblonghe, delle quali ciascuna
+            ha quattro compartimenti ove sono intagliate ed ai numeri 2 e 9 sta la marca
+            dell’intagliatore A. D. in corsivo iniziali. Oltre 12 tavole è anche nella stessa forma
+            intagliato e figurato il frontespizio.</note>
+      </bibl></item>
+   <item xml:id="c1d1e26073" n="1557" corresp="dcl:85x dcl:sp2">
+      <label>1557.</label>
+      <bibl><author>AMATIUS Paschalis Sabinianensis</author>, <title>De restituitone
+            purpuraru</title>, <pubPlace>Lucae</pubPlace>
+         <date>1781</date>, in fol., M. 82. <note>Splendidissima edizione con bei tipi e bella carta
+            accuratissima, che onora l’autore e il tipografo Giacomo Giusti.</note>
+      </bibl></item>
+   <item xml:id="c1d1e26104" n="1562">
+      <label>1562.</label>
+      <bibl><author>S. AUBIN Aug.</author>, <title>C’est ici les differens jeux de petits polissons
+            de Paris</title>, <date>1770</date>, in fol., M. 105. <note>Sono sei fogli intagliati
+            con infinito buon gusto e graziosissimi per il disegno e per l’esecuzione.</note>
+      </bibl></item>
+   <item xml:id="c1d1e26215" n="1578">
+      <label>1578.</label>
+      <bibl><author>BAUR Giovan Guglielmo</author>, (a D. Paolo Orsino Duca di Bracciano tav. D. D.)
+            <title>Costumi di diverse nazioni</title> p. in 8, <date>1636</date>, 12 tavole
+         originali a cui sono unite anche le riproduzioni delle stesse pubblicate nella calcografia
+         di Mariette il figlio per opera di F. L. D. Ciartres. <note>Su legato nell’opera delle
+            battaglie di Baur.</note>
+      </bibl></item>
+   <item xml:id="c1d1e26247" n="1583">
+      <label>1583.</label>
+      <bibl><title>BELLEZZE de recami et dessegni</title>, opera nova non men bella che utile e
+         necessaria et non più veduta in luce, <pubPlace>Venezia</pubPlace>
+         <date>1558</date>. Carte 20 di ricami. — <bibl><title>Il Monte Opera nova di recami dove
+               trovansi varie mostre di punto in aere</title>, <pubPlace>Venezia</pubPlace>
+            <date>1557</date>, carte 16</bibl>. — <bibl><title>Le Pompe Opera nova per far cordelle
+               d’oro, di seta, di filo, ec.</title>, <pubPlace>Venezia</pubPlace>
+            <date>1657</date>, carte 16.</bibl> — <bibl><title>Lo Splendore delle virtuose giovani
+               con varie mostre di fogliami e punti in aere</title>, <pubPlace>Venezia</pubPlace>,
+            per <publisher>Iseppo Foresto</publisher> in calle dell’acqua a S. Zulian all’insegna
+            del Pellegrino, <date>1558</date>, carte 16.</bibl> — <bibl><title>Le Gloria et l’honore
+               de’ ponti tagliati et ponti in aere</title>, <pubPlace>Venezia</pubPlace>, per
+               <publisher>Mathio Pagan</publisher> in Frezzeria al segno della Fede,
+               <date>1558</date>, 16 carte.</bibl> — <bibl><title>Trionfo di Virtù Libro novo da
+               cucir, con fogliami, ponti a fili, ponti cruciati ec.</title>,
+               <pubPlace>Venezia</pubPlace>
+            <date>1559</date>, 16 carte.</bibl> — <bibl>In fine: <title>Burato, questi sono quattro
+               foglietti con mostre di tela chiara a quadretti per fare opere di punto in varie
+               larghezze, ove e marcala gradatamente l’opera più o meno fitta e sta in gran
+               caratteri a retro dell’ultima pagina, P. Alex. Pag. Benacenses F. Bena V. V.</title>
+            <note>Tutti questi opuscoli legati m un volume. Nei diversi frontespizi indicati sono
+               figure di bellissimo disegno e le operette tutte, riunite in questo rarissimo
+               volumetto, il più bello che di tal genere da noi si conosca, contengono 104 carte
+               oltre a 200 tavole elegantissime. Esemplare di bellissima conservazione. Vedi
+                     <bibl><author>Vinciolo</author></bibl>,
+                  <bibl><author>Passerotti</author></bibl>,
+               <bibl><author>Vavassore</author></bibl>.</note></bibl>
+      </bibl></item>
+   <item xml:id="c1d1e26309" n="1592">
+      <label>1592.</label>
+      <bibl><author>BOEMO Aubano Giovanni alemanno</author>, <title>Li costumi, le leggi, le usanze
+            di tutte le genti</title>, raccolte qui insieme da molti illustri scrittori e tradotte,
+         per il Fauno in questa nostra lingua volgare, <pubPlace>Venezia</pubPlace>
+         <date>1542</date>, per <publisher>Mich. Tramezzino</publisher>, in 8. <note>Questo è un
+            libro singolare pieno di cose meravigliose tolte da racconti favolosi, da viaggiatori,
+            da pregiudizi, <fw type="foot"/>
+            <pb type="memofonte"/>
+            <fw type="head"/> senza critica, ma che presenta il quadro esatto delle opinioni di di
+            quel secolo.</note>
+      </bibl></item>
+   <item xml:id="c1d1e26335" n="1595">
+      <label>1595.</label>
+      <bibl><author>BONANNI Filippo</author>, <title>Catalogo degli ordini equestri e militari
+            esposto in imagini</title>, diviso in 3 parti, <pubPlace>Roma</pubPlace> dal <date>1741
+            al 1743</date>, vol. 3 in 4. Latino e italiano. <note>Le tavole furono intagliate da
+            Arnoldo Wan Westerowd. Nel primo vol. sono tav. 166, nel secondo 108, nel terzo 75, ad
+            ognuna delle quali sta contraposta la relativa storica illustrazione.</note>
+      </bibl></item>
+   <item xml:id="c1d1e26366" n="1600">
+      <label>1600.</label>
+      <bibl><author>BOSSI Hieronymi</author>, <title>De toga romana commentarius</title>. Accedit ex
+         Philippo Rubenio iconismus statuae toga tuae etc., <pubPlace>Amstelodami</pubPlace>
+         <date>1671</date>, in 12. <note>La tavola tolta dal Rubenio, che è in 4, trovasi piegata in
+            questo libretto, a car. 82.</note>
+      </bibl></item>
+   <item xml:id="c1d1e26423" n="1607" corresp="dcl:48m">
+      <label>1607.</label>
+      <bibl><author>BRUYNI Abrahami</author>, <title>Diversarum gentium armatura equestris</title>,
+            <pubPlace>Amstelodami</pubPlace> in redibus <publisher>Nicolai Joan,
+            Visscherii</publisher>. Vedi Diversarim gentium. <pb type="cico" n="279"/>
+      </bibl></item>
+   <item xml:id="c1d1e26475" n="1615">
+      <label>1615.</label>
+      <bibl><title>Caracteres dramatiques, ou portraits du théatre anglais</title>,
+            <pubPlace>Londres</pubPlace>
+         <date>1770</date>, auxquels en a adjoint plusieurs autres du théatre français, gravés et
+         illuminés sur parchemin, en 8. <note>Queste piccole figure del teatro inglese in numero di
+            40 miniate con gusto ed esattezza pubblicate (suivant l’acte du Parlement) presentano
+            l’usanze del secolo al tempo di Gar <pb type="cico" n="280"/>rich a mano a mano che
+            l’editore Sayer le andava pubblicando. Quelle del teatro francese sono parimenti miniate
+            in numero di 34, nove delle quali in pergamena; e si conservano con diligenza i modi e
+            gli abiti di Le Kain, di Brizart, di Molé, di Mademoiselles Clairon e Dusmenil
+            ec.</note>
+      </bibl></item>
+   <item xml:id="c1d1e26505" n="1619" corresp="dcl:1w5">
+      <label>1619.</label>
+      <bibl><author>CAVALLUCCI Vincenzo</author>, <title>Del modo di tinger la porpora degli
+            antichi</title>, <pubPlace>Perugia</pubPlace>
+         <date>1786</date>, in ottavo, M. 63. </bibl></item>
+   <item xml:id="c1d1e26549" n="1626" corresp="dcl:mfx">
+      <label>1626.</label>
+      <bibl><author>CIAMPI Sebastiano</author>, <title>Statuti suntuari ricordati dal Villani circa
+            il vestiario delle donne e le pompe nuziali e funerali, dati in luce con
+            annotazioni</title>, <pubPlace>Pisa</pubPlace>
+         <date>1815</date>, in 4, M. 25. </bibl></item>
+   <item xml:id="c1d1e26598" n="1633">
+      <label>1633.</label>
+      <bibl><title>DISCORSO breve dell’insegne pinte delle famiglie nobili nel quale si disputa
+            s’elle fussero appresso gli antichi in uso.</title>
+         <note>Opuscoletto manoscritto di sedici pagine di testo ed esteso con molta dottrina e buon
+            gusto di stile. </note>
+      </bibl></item>
+   <item xml:id="c1d1e26686" n="1646">
+      <label>1646.</label>
+      <bibl><author>FAUSTO da Longiano</author>, <title>Delle nozze, trattato in cui si leggono i
+            riti, costumi, cerimonie ec. di diversi popoli onde si sono tratti molti problemi,
+            aggiuntivi i precetti matrimoniali di Plutarco, Venezia per Plinio Pietra Santa</title>,
+            <date>1554</date>, in 4. <note>Il libretto elegantemente stampato e raro con
+            frontespizio figurato, è dedicato all’illustrissima S. Virginia S. di Piombino. Contiene
+            in tutto ventiquattro foglietti. </note>
+      </bibl></item>
+   <item xml:id="c1d1e26700" n="1648">
+      <label>1648.</label>
+      <bibl><author>FERRARIO Giulio</author>, <title>Del costume antico e moderno dì tutti i
+            popoli</title>, <pubPlace>Milano</pubPlace>
+         <date>i8i5</date> in 4- gr. con <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/> figure miniate. <note> Opera che si sta pubblicando con molto decoro ed
+            utilità. Estratti da tutti i più scelti libri di costumi, viaggi ed antichità. </note>
+      </bibl></item>
+   <item xml:id="c1d1e26758" n="1656">
+      <label>1656.</label>
+      <bibl><author>FRANZENII Jo. Ernesti</author>, <title>Commentario de funeribus veterum
+            christianorum cum prefatione Fabricii Helmstadii</title>, <date>1709</date>, in 8, M.
+         73. <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/><note> Opera divisa in 4 libri, estesa a 448 pagine e ripiena di
+            erudizione. </note>
+      </bibl></item>
+   <item xml:id="c1d1e26770" n="1657" corresp="dcl:9rz">
+      <label>1657.</label>
+      <bibl><author>GAYA</author>, <title>Cérémonies nuptiales de toutes les nations</title>,
+            <pubPlace>Paris</pubPlace>
+         <date>1681</date>, in 8. <note>Piccolo e raro libretto di 72 pag. della Bibl. di
+            Malborough.</note>
+      </bibl></item>
+   <item xml:id="c1d1e26809" n="1663">
+      <label>1663.</label>
+      <bibl><author>De GLEN Jean</author>, <title>Discours sur la varieté des habits et de coustumes
+            de l’Europe</title>, <date>1601</date>. <note>Sonovi oltre 200 tavole in legno eseguite
+            alla maniera di quelle del Vecellio. Libro rarissimo a vedersi.</note>
+      </bibl></item>
+   <item xml:id="c1d1e26893" n="1675">
+      <label>1675.</label>
+      <bibl><author>Le HAY</author>, <title>Recueil de cent estampes réprésentantes differentes
+            nations du Levant, tirées sur les tableaux peints d’aprés nature par les ordres de
+            Monsieur de Ferriol Ambassadeur du Roi à la Porte</title>, <pubPlace>Paris</pubPlace>
+         <date>1714</date>, in fol. <note>Questo esemplare apparteneva alla biblioteca di M. Crozat
+            ed è di prima edizione, quantunque vi sieno le <fw type="foot"/>
+            <pb type="memofonte"/>
+            <fw type="head"/> spiegazioni, le 3 tavole addizionali intitolate Enterremens turques,
+            Derviches qui tourent e una pagina di musica, le quali per solito non trovatisi riunite
+            che nell’edizione dell’anno posteriore. Legato in mar. dorato. </note>
+      </bibl></item>
+   <item xml:id="c1d1e26917" n="1678" corresp="dcl:pjs">
+      <label>1678.</label>
+      <bibl><author>ITALIAN Scenery</author>, <note>Vedi Bonaiuti</note>. </bibl></item>
+   <item xml:id="c1d1e26942" n="1682">
+      <label>1682.</label>
+      <bibl><author>KORNMANNI</author>, <note> De annulorum origine, Vedi Kirchmanni. </note>
+      </bibl></item>
+   <item xml:id="c1d1e26960" n="1685">
+      <label>1685.</label>
+      <bibl><author>LEONARDI de Portis</author>, <title>De sestetio, pecuniis, ponderibus et
+            mensuris antiquis libri duo. Editio seculi XV, sine loco et anno,</title> in 4.
+            <note>L’opuscolo fu pubblicato dall’Egnazio e stampato probabilmente a Venezia con
+            caratteri rotondi e di bella forma. </note>
+      </bibl></item>
+   <item xml:id="c1d1e26991" n="1689">
+      <label>1689.</label>
+      <bibl><author>LIEBAU Jean</author>, <title>Trois livres de l’embellissement et ornement du
+            corps humain</title>, <pubPlace>Paris</pubPlace>
+         <date>1782</date>, in 8. </bibl></item>
+   <item xml:id="c1d1e27028" n="1694" corresp="dcl:hk0">
+      <label>1694.</label>
+      <bibl><author>LOYER Pierre</author>, <title>Discours et histoires des spectres, visions et
+            apparitions des esprits, anges, démons et âmes se montrans visibles aux hommes: divise
+            en huit livres</title>, <pubPlace>Parigi</pubPlace>
+         <date>1605</date>, in 4. <note> Opera curiosa di oltre mille pagine di testo, con cui è
+            percorsa amplissimamente questa materia.</note>
+      </bibl></item>
+   <item xml:id="c1d1e27108" n="1706" corresp="dcl:tv8">
+      <label>1706.</label>
+      <bibl><author>MAVELOT C.</author>, <title>Chiffres</title>. Nouveau livre par alphabet à
+         simples traits, où se trouvent tous les noms et surnoms, <pubPlace>Paris</pubPlace>
+         <date>1684</date>, in 8. </bibl></item>
+   <item xml:id="c1d1e27133" n="1710">
+      <label>1710.</label>
+      <bibl><author>MEOLA Gio. Vin.</author>, <title>Dissertazione intorno le gabbiuole degli
+            uccelli avute in uso dagli antichi</title>, <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+         <pubPlace>Napoli</pubPlace>
+         <date>1767</date>, in 8, fig. M. 35. <note>Con alcuni monumenti nel frontespizio e fra il
+            testo intagliati in rame.</note>
+         <pb type="cico" n="296"/>
+      </bibl></item>
+   <item xml:id="c1d1e27153" n="1712" corresp="dcl:b2p">
+      <label>1712.</label>
+      <bibl><author>MERCURIALIS Hieron. Foroliv.</author>, <title>De Arte Gymnastica libri sex,
+            editio tertia</title>, <pubPlace>Venetiis</pubPlace>, apud
+            <publisher>Junctas</publisher>, <date>1587</date>, in 4, fig. <note>Le tavole in questa
+            edizione sono tutte in legno ai luoghi indicati nel testo.</note>
+      </bibl></item>
+   <item xml:id="c1d1e27241" n="1725">
+      <label>1725.</label>
+      <bibl><author>NEGHI Cesare milanese detto il Trombone</author>, <title>Nuova <pb type="cico"
+               n="298"/> invenzione di balli</title>, opera vaghissima divisa in tre trattati,
+            <pubPlace>Milano</pubPlace>
+         <date>1604</date>, in fol. fig. <note>Le figure di questo volume, in numero di 58 oltre il
+            ritratto dell’autore, furono disegnate da Gio. Mauro Boveri milanese detto il
+            Fiamminghino e furono intagliate da Leone Pallavicino. L’autore intitola li 8 trattati
+            Grazie d’amore e trovasi anche impressa a’ suoi luoghi la musica dei balletti.</note>
+      </bibl></item>
+   <item xml:id="c1d1e27253" n="1727" corresp="dcl:pvg">
+      <label>1727.</label>
+      <bibl><author>NERI Antonio</author>, La stessa opera stampata in <pubPlace>Venezia</pubPlace>
+         presso <publisher>Niccolò Pezzana</publisher>, <date>1787</date>, in 8. </bibl></item>
+   <item xml:id="c1d1e27272" n="1730" corresp="dcl:58v">
+      <label>1730.</label>
+      <bibl><author>NICOLAI</author>, <title>Les quatre premiers livres des navigations et
+            peregrinations orientales avec les figures au naturel tant d’ hommes, que des
+            femmes</title>, à <pubPlace>Lion</pubPlace>
+         <date>1568</date>, in fol. fig. <note>Citasi un’edizione del 1567, ma Brunet è d’opinione
+            che già la medesima di questa. Le tavole sono di prima impressione e ragionevol disegno
+            in numero di 60. È duopo in questi viaggi osservare se sia mutilata la tavola a carte
+            114 intitolata. Calendrier Religieux Turc.</note>
+      </bibl></item>
+   <item xml:id="c1d1e27309" n="1735">
+      <label>1735.</label>
+      <bibl><author>NONNII Ludovici</author>, <title>Diaeteticon, sive de re cibaria libri
+            quatuor:</title> nunc primum lucem vidit, <pubPlace>Antuerpiae</pubPlace>
+         <date>1646</date>, in 4. <note>Con indice amplissimo delle materie eruditissime che
+            compongono quest’opera.</note>
+      </bibl></item>
+   <item xml:id="c1d1e27397" n="1748">
+      <label>1748.</label>
+      <bibl><author>PASSEROTTI Aurelio</author>, Pittore bolognese, dissegnatore e miniatore figlio
+         di Bartolommeo Passerotti circa al 1560 (Vedasi Malvasia e Abec. Pit.), <title>Libro primo
+            di lavorieri alle molto illustri et virtuosissi <pb type="cico" n="301"/> me gentildonne
+            bolognesi. Libro secondo alla molto magnifica et virtuosissima signora ...</title>, in
+         fol. obl. <note>Questo è un libretto di disegni vari di ricami con stemmi ed allegorie
+            disegnato a penna, preceduto da’ citati due frontespizi con lettere dedicatorie, alle
+            quali va innanzi un primo frontespizio miniato riccamente ove è una Devise con un
+            girasole, e in una targa: non san questi occhi miei volgersi altrove. Sono carte 67 in
+            tutto, comprese le due dedicatorie e il frontespizio. Vedi agli articoli Bellezze,
+            Vinciolo, Vavassore.</note>
+      </bibl></item>
+   <item xml:id="c1d1e27422" n="1752">
+      <label>1752.</label>
+      <bibl><author>PERUCCI Francesco</author>, <title>Pompe funebri di tutte le nazioni del mondo,
+            raccolte dalle storie sacre e profane</title>; dedicate al Sig. Claudio Basetti,
+            <date>1639</date>, in 4, figurato. <note>Trenta sono le tavole intagliate in rame con
+            bassa mediocrità in quest’opera divisa in 7 libri: fra le quali vennero copiate tutte
+            quelle del Porcacchi.</note>
+      </bibl></item>
+   <item xml:id="c1d1e27428" n="1753" corresp="dcl:75q">
+      <label>1753.</label>
+      <bibl><author>PERUCCI Francesco</author>, <title>Pompe funebri di tutte le nazioni del
+            mondo,</title>
+         <pubPlace>Verona</pubPlace>
+         <date>1646</date>, in 4, obl. fig. <note>Questa è una seconda edizione di minor pregio
+            della prima, quantunque riveduta e corretta, poiché le tavole sono logore.</note>
+      </bibl></item>
+   <item xml:id="c1d1e27460" n="1757">
+      <label>1757.</label>
+      <bibl><author>PETRONI Alexandri</author>, <title>De victu Romanorum et de sanitate
+            tuenda</title>. Libri quinque, <pubPlace>Roma</pubPlace>, in aedibus Populi Romani,
+            <date>1581</date>, in fol. <note>Questo insigne medico dedicò la sua opera a Gregorio
+            XIII e la corredò di molte preziose notizie. Edizione di bellissima esecuzione.</note>
+      </bibl></item>
+   <item xml:id="c1d1e27549" n="1770" corresp="dcl:pjt">
+      <label>1770.</label>
+      <bibl><title>PROVISIONE novissima delle dote e dello ornato delle donne reformata al tempo del
+            Reverendissimo Sig. Bernardo de’ Rossi governatore pres. et vicel. di Bologna e di tutta
+            Romagna</title>, impressa in <pubPlace>Bologna</pubPlace> per maestro
+            <publisher>Girolamo de’ Benedetti</publisher>, <date>1521</date>, in 8, M. 54.
+            <note>Questa disposizione data per moderare il lusso di Bologna si estende in
+            singolarissimi argomenti che interessano per le costumanze del vestiario e degli
+            ornamenti di quell’età. Sono 23 capitoli, seguiti da un Breve di Leone X in 12 foglietti
+            di stampa col frontespizio. Opuscolo raro.</note>
+      </bibl></item>
+   <item xml:id="c1d1e27573" n="1774">
+      <label>1774.</label>
+      <bibl><title>RACCOLTA di caricature di Parigi e di Londra</title>, delle quali 41 sono
+         eseguite in Francia e 24 in Inghilterra. Saggio scelto fra le più singolari e curiose.
+            <note>Le prime sono quasi tutte di Orazio Vernet.</note>
+      </bibl></item>
+   <item xml:id="c1d1e27592" n="1776" corresp="dcl:h5b">
+      <label>1776.</label>
+      <bibl><title>RÉCUEIL des habillemens de differentes nations anciennes et modernes et en
+            particulier de vieux ajustemens anglais d’après les desseins d’Holbein, Wandyk, Hollar
+            au quel sont ajoutés les habits des principaux caracteres du theatré anglais</title>, 2
+         vol. en 4, fig., 1757. Inglese e francese. <note>Sono queste 240 tavole con brevi
+            illustrazioni e l’indicazione dell’anno in cui si costumavano le foggie disegnate dei
+            diversi vestimenti nei rispettivi paesi, il che è utilissimo per precisare il costume
+            teatrale ed evitare gli anacronismi.</note>
+      </bibl></item>
+   <item xml:id="c1d1e27704" n="1793">
+      <label>1793.</label>
+      <bibl><author>SCHEFFERII Joannes</author>, <title>De antiquorum torquibus, cum notis Jo.
+            Nicolai</title>, <pubPlace>Hamburgi</pubPlace><date> 1707</date>, in 8, M. 72.
+      </bibl></item>
+   <item xml:id="c1d1e27725" n="1795" corresp="dcl:h8c dcl:n82">
+      <label>1795.</label>
+      <bibl><author>SECONDO Ferdinando</author>, <title>Della vita pubblica de’ Romani. Vol. 2 in
+            uno,</title><pubPlace> Napoli</pubPlace><date> 1784</date>, in 12. </bibl></item>
+   <item xml:id="c1d1e27731" n="1796" corresp="dcl:fk3">
+      <label>1796.</label>
+      <bibl><author>SIEPI Serafino</author>, <title>Della equitazione muliebre, discorso</title>,
+            <pubPlace>Perugia</pubPlace><date> 1813</date>, in 8. <note>Questo è un volumetto di 134
+            pagine e diviso in 3 parti. Comincia coll’equitazione di Eva e finisce con un sonetto
+            invito di Pallade che è l’interpretazione d’un’immagine a guisa di medaglione posta nel
+            frontispizio</note>. </bibl></item>
+   <item xml:id="c1d1e27743" n="1798" corresp="dcl:rzc">
+      <label>1798.</label>
+      <bibl><author>SPANDUGINO Teodoro</author>, <title>Commentari dell’origine de’ principi turchi
+            e de’ costumi di quella nazione</title>, <pubPlace>Torrentino</pubPlace><date>
+            1551</date>, in 8. <note>Operetta stampata in bei caratteri corsivi e ripiena di notizie
+            curiose e interessanti per la storia e le usanze di quei popoli</note>. </bibl></item>
+   <item xml:id="c1d1e27823" n="1810" corresp="dcl:kg3">
+      <label>1810.</label>
+      <bibl><author>TORACA Gaetano</author>, <title>Delle antiche Terme Taurine esistenti nel
+            territorio di Civitavecchia,</title><pubPlace> Roma</pubPlace>
+         <date>1761</date>, in 4, M. 39. <pb type="cico" n="310"/>
+      </bibl></item>
+   <item xml:id="c1d1e27838" n="1812">
+      <label>1812.</label>
+      <bibl><author>TRAITÉ</author><title> des voitures.</title><note> Vedi sui trattati di
+            equitazione e cavalli.</note>
+      </bibl></item>
+   <item xml:id="c1d1e27868" n="1817" corresp="dcl:mvh">
+      <label>1817.</label>
+      <bibl><author>De VASCULIS libellus adolescentulorum causa ex Bayfio decerptus</author>,
+            <title>addita vulgari latinarum vocum interpretatione</title>,
+            <pubPlace>Lugduni</pubPlace><date> 1536</date>, in 8. </bibl></item>
+   <item xml:id="c1d1e27875" n="1818">
+      <label>1818.</label>
+      <bibl><author>VAVASSORE detto Guadagnino Giovanni Andrea</author>, <title>Esemplario novo di
+            più di cento variate mostre di qualunque sorte bellissime per cucire intitulato Fontana
+            de gli esempli</title>, <date>1550</date>, in 4, obl. <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+         <note>Nel frontespizio è una fontana col motto Sollicitudo est mater divitiarum, e
+            lateralmente Donne e donzelle che el cusir segnile (per farvi eterne alla fonte venite)
+            a retro del frontesp. sta la dedica cosi intestata. Il Pelliciolo alta molto magnifica
+            Madonna Lippomana Signora e Padrona Osservandissima, dopo la quale finisce la pagina con
+            un sonetto. Seguono quattordici foglietti impressi da ambo i lati con 28 disegni
+            intagliati in legno di vari punti e ricami e nel foglio ultimo dopo questi è un avviso
+            ALLE VIRTUOSE DONNE et a qualunque lettore Giovan Andrea Vavassore detto Guadagnino.
+            Nuovamen <pb type="cico" n="311"/>te stampato ec. Le prime opere prodotte da questo
+            intagliatore e tipografo erano assai più rozze (Vedi la sua Biblia Pauperum). Ma siccome
+            precedono di molli anni questa ristampa, fatta però lui vivente, si scorge l’avanzamento
+            ch’egli aveva fatto nell’arte sua. Vedi agli articoli Bellezze, Vinciolo,
+            Passerotti.</note>
+      </bibl></item>
+   <item xml:id="c1d1e27887" n="1819" corresp="dcl:mg1">
+      <label>1819.</label>
+      <bibl><author>VECELLIO Cesare</author>, <title>Habiti antichi et moderni di tutto il mondo, di
+            nuovo accresciuti di molte figure. Poi nello stesso frontespizio segue il latino:
+            Vestitus antiquorum recentiorumque totius orbis per Sulstatium Gratilianum Senapolensem
+            latine declarati. In Venezia, appresso i Sessa.</title> In fine: in
+            <pubPlace>Venezia</pubPlace><date> 1598</date>, in 8. <note>Con la dedica al Sig. Pietro
+            Montalbano italiana e latina e i cataloghi e il testo esplicativo delle tavole latino e
+            italiano, libri 12 con tavole in legno 522. Opera delle migliori che si conoscano fra le
+            antiche di questo genere. La prima edizione comparve nel 1590.</note>
+      </bibl></item>
+   <item xml:id="c1d1e27893" n="1820" corresp="dcl:vrm">
+      <label>1820.</label>
+      <bibl><author>VENTURI Giovan Battista</author>, <title>Rapporto della Commissione di commercio
+            al Gran Consiglio sopra un nuovo campione di misura lineare</title>, con annotazioni,
+            <pubPlace>Milano</pubPlace><date> anno VI</date>. </bibl></item>
+   <item xml:id="c1d1e27899" n="1821">
+      <label>1821.</label>
+      <bibl><author>VERNET Horace</author>, <title>Les merveilleuses et les incroyables de Paris:
+            Aggiunto Lanté, Les costumes et les cris etc.,</title><pubPlace> Paris</pubPlace>, in
+         fol. <note>Sono queste 79 tavole assai ben disegnate, intagliate e acquarellate con gusto,
+            che presentano i moderni costumi di Francia, delle quali 32 appartengono al primo e 10
+            al secondo autore. Vi sono aggiunte di Orazio Vernet le Ore del giorno in sei stampine
+            in 8 di due figure ciascuna aggruppate, che sono di bellissima esecuzione.</note>
+      </bibl></item>
+   <item xml:id="c1d1e27905" n="1822">
+      <label>1822.</label>
+      <bibl><author>VINCIOLO (de) venitien seigneur Federic</author>, <title>Les singuliers et
+            nouveaux pourtraicts pour toutes sortes d’ouvrages de lingerie, à Thurin par Eleazaro
+            Thomysi</title>, <date>1658</date>, in 8, fig. <note>Quest’operetta è divisa in due
+            parti riunite in on volume. La prima che è composta di 44 foglietti, ove sono 39 tavole
+            di bella esecuzione e invenzione è preceduta dal frontespizio, dietro cui è il ritratto
+            d’Enrico III re di Francia, poi un avvertimento ai lettori, il ritratto della regina e
+            la dedica dell’opera, indi un sonetto alle dame e alle donzelle: tutta questa prima
+            parte contiene l’ouvrage ou point coupé. La seconda parte contiene 36 foglietti o carte
+            stampate da amendue i lati, con disegni a punto in quadro e col numero delle <pb
+               type="cico" n="312"/> maglie nel tessuto delle tele per simili opere ec. Il volumetto
+            in tatto e di 86 carte con 109 stampe in legno. Vedi agli articoli Bellezze, Vavassore,
+            Passerotti.</note>
+      </bibl></item>
+   <item xml:id="c1d1e27911" n="1823" corresp="dcl:czr">
+      <label>1823.</label>
+      <bibl><author>Del VOLO</author>, <title>Dialogo diviso in tre mattine in 8, figurato.</title>
+         D’autore anonimo, M. 55. <note>Dedicato al sig. Marcantonio Sabatini bolognese. Quest’opera
+            è scritta con lepidezza piuttosto fratesca: infatti è da credersi estesa da qualche
+            frate poiché rilevasi che l’autore aveva stampato un poemetto intitolato: Gli occhi di
+            Gesù.</note>
+      </bibl></item>
+   <item xml:id="c1d1e27924" n="1825" corresp="dcl:hvs">
+      <label>1825.</label>
+      <bibl><author>WARBURTON</author>, <title>Dissertazione sulla iniziazione a’ misteri Eleusini,
+            ovvero spiegazione del libro VI di Virgilio</title>, <pubPlace>Venezia</pubPlace><date>
+            1793</date>, in 12, M. 67. <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+      </bibl></item>
+   <item xml:id="c1d1e27942" n="1827" corresp="dcl:dc9">
+      <label>1827.</label>
+      <bibl><author>WELLER Singer Samuel</author>, <title>Researches into the history of playing
+            cards with illustrations of the origin of printing and engraving on wood</title>,
+            <pubPlace>London</pubPlace><date> 1816</date>, fig. in 8, gr. <note>Opera dottissima e
+            interessante con molti fac simile di accurato intaglio in rame ed in legno, collocati
+            fra il testo, molti dei quali stampati in carta della China.</note>
+      </bibl></item>
+   <item xml:id="c1d1e27948" n="1828">
+      <label>1828.</label>
+      <bibl><author>WOOD John</author>, <title>An essay fowards a description of batti in four
+            partes 2 vol.,</title><pubPlace> London</pubPlace><date> 1749</date>, in 8, figur.
+      </bibl></item>
+   <item xml:id="c1d1e27954" n="1829">
+      <label>1829.</label>
+      <bibl><author>ZOMPINI</author>, <title>Le arti, che vanno per via nella città di Venezia
+            inventate ed incise</title>, <date>1789</date>, in fol. <note>Son tavole 40, non
+            compreso il frontespizio figurato e l’elenco, le quali furono incise con gran maestria e
+            facilità pittoresca: divenute rarissime, poiché le lamine disperse, o convertite ad
+            altro uso non ne tirarono che pochi esemplari. M. 105.</note></bibl></item>
+   <item xml:id="c1d1e28014" n="1836" corresp="dcl:c2q">
+      <label>1836.</label>
+      <bibl><author>ALCIATI Andreae</author>, <title>Emblemata: nunc recens adiecta sunt epimythia
+            quibus emblematum amplitudo</title>
+         <pb type="cico" n="314"/> et obscura illustrantur, <pubPlace>Lugduni</pubPlace>, ap.
+            <publisher>Haered. Gul. Rovilii</publisher>, <date>1616</date>, in 16, fig. <note>Sono
+            gli stessi intagli in legno dell’elegante edizione del 1549 stampati senza
+            contorno.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28065" n="1843" corresp="dcl:qvd">
+      <label>1843.</label>
+      <bibl><author>BARGIGLI Scipione</author>, <title>Delle imprese; alla p. parte, la 2 e la 3
+            nuovamente aggiunte</title>, <pubPlace>Venezia</pubPlace>, presso <publisher>il
+            Franceschi</publisher>, <date>1504</date>, in 4, fig. <note>Col ritratto di Ridolfo II e
+            la sua impresa, oltre le numerose tavole delle imprese dei principali signori d’Italia,
+            intagliate in rame</note>. </bibl></item>
+   <item xml:id="c1d1e28077" n="1845" corresp="dcl:p5b">
+      <label>1845.</label>
+      <bibl><author>BENEDETTI Felice</author>, <title>Le imprese di D. Filippo d’Austria II, Re di
+            Spagna, rappresentate dopo la sua morte nel tumulo eretto nella città
+            dell’Aquila</title>, <date>1589</date>, ivi in 4. <note>Edizione d’un’opera mediocre e
+            pubblicata per adulare bassamente un uomo, che la storia vorrebbe dimenticare, come
+            saranno dimenticate le tavole mal intagliale di questo libro.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28171" n="1858" corresp="dcl:308">
+      <label>1858.</label>
+      <bibl><author>BORSETTA Cesare</author>, <title>Discorsi della natura delle imprese e della
+            modestia descrittori</title>, <pubPlace>Verona</pubPlace>, nella stamperia di
+            <publisher>Angelo Tamo</publisher>, <date>1602</date>, in 4. <note>Opuscoletto singolare
+            e stampato in bei caratteri rotondi difficile a trovarsi.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28196" n="1862">
+      <label>1862.</label>
+      <bibl><author>BRY (DE) Teodori</author>, <title>Proscenium vitae humanae sive emblematum
+            saecularium iucundissima et artificiosissima varietate vitae humanae etc. etc. versibus
+            latinis, germanicis, gallicis et belgicis etc. decades septem</title>,
+            <pubPlace>Francf.</pubPlace>, per <publisher>Theod. de Bry</publisher>,
+            <date>1621</date>, in 8. Con elegantissime e rare incisioni in 74 tavole, delle quali
+         una è il frontespizio, l’altra il typus amicitiae e 71 gli emblemi. Libro difficile a
+         trovarsi senza mutilazioni per i soggetti liberi in esso espressi. </bibl></item>
+   <item xml:id="c1d1e28202" n="1863" corresp="dcl:d5n">
+      <label>1863.</label>
+      <bibl><author>BRY (DE) Teodori</author>,<title> Acta Mechmetii Saracenorum Principis: addita
+            Vaticinia Severi et Leonis in oriente Imp. cum quibusdam aliorum etc. iconibus
+            artificiose in aere sculptis passim exornata sine loco</title>,
+            (<pubPlace>Francofurti</pubPlace>) <date>1597</date>, in 4. <note>Dieci tavole oltre il
+            bellissimo frontespizio ornano il primo opuscoletto e 16 emblemi intagliati con grande
+            accuratezza trovatisi nel secondo In tutto tavole 26 accompagnate dal testo
+            relativo.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28221" n="1866" corresp="dcl:ck7">
+      <label>1866.</label>
+      <bibl><author>CALLOT Jacques</author>, <title>Lux Claustri, la lumiere du cloustre representée
+            par figures emblematiques</title>, <pubPlace>Paris</pubPlace>, chez
+            <publisher>Langlois</publisher>, <date>1646</date>, in 4. <note>Ventisette tavole
+            illustrate con versi latini.</note>
+         <pb type="cico" n="319"/>
+      </bibl></item>
+   <item xml:id="c1d1e28247" n="1869" corresp="dcl:2w7">
+      <label>1869.</label>
+      <bibl><author>CAMERARII Joach.</author>, <title>Symbolorum et emblematum centuriae
+            tres</title>, <date>1605</date>, in 4, fig. Accedit noviter centuria 4 ex aquatilibus et
+         reptilibus. <note>Opera ricca e di bella esecuzione con 400 tavole. Esemplare della Bibl.
+            di Malborough.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28266" n="1872" corresp="dcl:5ch">
+      <label>1872.</label>
+      <bibl><author>CAUSSINO Nicolao</author>, <title>Symbolica Aegyptioriun sapientia olim ab eo
+            scripta</title>, nunc post varias editiones denuo edita, <pubPlace>Parisiis</pubPlace>
+         <date>1647</date>, M. 65. <note>In questo libro sono prodotte le opere di Horus Apollo, di
+            Clemente Alessandrino, di S. Epifanio, con molte altre illustrazioni intorno al soggetto
+            dei geroglifici.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28272" n="1873" corresp="dcl:29f">
+      <label>1873.</label>
+      <bibl><author>CAUSSINO Nicolao</author>, La stessa, colla <bibl>continuazione intitolata
+               <title>Polysthor Symbolicus electorum Symbolorum et parabolarum historicurum stromata
+               XII libris complectens</title>, <pubPlace>Parisiis</pubPlace>
+            <date>1646</date>, in 4.</bibl>
+      </bibl></item>
+   <item xml:id="c1d1e28278" n="1874" corresp="dcl:3w5">
+      <label>1874.</label>
+      <bibl><author>CONTILE Luca</author>, <title>Ragionamento sopra la proprietà delle imprese con
+            le particolari degli accademici <pb type="cico" n="320"/> affidati e cotte
+            interpretazioni e cronache</title>, <pubPlace>Pavia</pubPlace>, presso
+            <publisher>Girolamo Bartoli</publisher>, <date>1574</date>, in fol. fig.
+            <note>Bellissima edizione con 109 tavole di buon intaglio.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28297" n="1877" corresp="dcl:gc8">
+      <label>1877.</label>
+      <bibl><author>CUSTODIS Raphaelis</author>, <title>Emblemata Amoris</title>,
+            <pubPlace>Augu.</pubPlace>
+         <date>1626</date>, in 4, fig. <note>La prima parte fa impressa nel 1696, la seconda nel
+            1631: quella contiene 50 tavole, questa 24: sono di bella esecuzione sullo stile di
+            Otone Verno. Esempl. della Bib. del D. di Malborough.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28303" n="1878">
+      <label>1878.</label>
+      <bibl><author>DAVID Virtuosus</author>, <title>A Theod. de Bry</title>, <date>1644</date>, cum
+         tab. 40, in 8, oblong. <note>Questa è la storia di Davide tratta dal genesi, colle
+            spiegazioni di contro alle tavole in latino e in tedesco.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28377" n="1889">
+      <label>1889.</label>
+      <bibl><title>EMBLEMI in occasione della nascita di Giuseppe Primo d’Austria</title>, 105.
+            <note>Sono queste cinque gran tavole a mezzo tinto, o a fumo eseguite da Elia Cristoforo
+            Heis.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28413" n="1894" corresp="dcl:1kj dcl:k5k">
+      <label>1894.</label>
+      <bibl><title>EMBLEMES ou dévises chretiennes</title>, <pubPlace>Utrect</pubPlace>
+         <date>1697</date>, in 8, fig. <note>Con cento tavole intagliate in rame di mediocre
+            esecuzione.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28420" n="1895" corresp="dcl:xfq">
+      <label>1895.</label>
+      <bibl><title>Les ENTRETIENS d’Ariste et d’Eugene</title>, <pubPlace>Paris</pubPlace>, chez
+            <publisher>Sebast. Marbré Cramoisy</publisher>, <date>1671</date>, in 12.
+            <note>S’aggirano questi dialoghi su vari argomenti, l’ultimo dei quali intitolato Les
+            dévises occupa 197 pagine.</note>
+         <pb type="cico" n="323"/>
+      </bibl></item>
+   <item xml:id="c1d1e28452" n="1900" corresp="dcl:18t">
+      <label>1900.</label>
+      <bibl><author>GIOVIO Monsig. Paolo</author>, <title>Ragionamento sopra i motti e i disegni
+            d’arme e d’amore che comunemente chiamano imprese</title>, con un discorso di Girolamo
+         Ruscelli intorno allo stesso <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/> soggetto, <pubPlace>Venezia</pubPlace>, per <publisher>Giordano
+            Ziletti</publisher>, <date>1560</date>, in 8. </bibl></item>
+   <item xml:id="c1d1e28491" n="1905" corresp="dcl:6p5 dcl:9k9 dcl:g5k">
+      <label>1905.</label>
+      <bibl><author>HEINSII Dan.</author>, <title>Poemata</title>, <pubPlace>Amst.</pubPlace>
+         <date>1618</date>, in 4, fig. <note>Questo libro e ricchissimo di piccole e diligenti
+            incisioni. Il testo e Olandese. Cominciano alcune poesie varie cogli allusivi rami: indi
+            due seguiti di Emblemi amatorj; lo specchio delle Donne illustri; gl'Inni a Bacco; il
+            Cantico a Gesucristo ec. Seguono gli Emblemi Cristiani e morali de Zaccaria Heins.
+            Roterdam 1625. E in fine la Scuola delle Giovani donne Tedesche. Tutte le numerose
+            tavole di quest'opera sono di accurata esecuzione e mediocre merito.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28528" n="1911" corresp="dcl:ck7">
+      <label>1911.</label>
+      <bibl><author>LANGLOIS Franciscus</author>, <title>Lux Claustri, La Lumiere du
+            Cloistre</title>. Representée par figures <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/> emblématiques dessinées et gravées par Jacques Callot,
+            <pubPlace>Paris</pubPlace>
+         <date>1646</date>, fig., in 4. </bibl></item>
+   <item xml:id="c1d1e28540" n="1912" corresp="dcl:fw3">
+      <label>1912.</label>
+      <bibl><title>LUX in tenebria</title>, Hoc est prophetiae donum quo Deus Ecclesiam Evangelicam
+         (in Regno Bohemiae) ornare ac paterne solari dignatus est. Cotteri revelationes,
+            <date>1667</date>, in 4, fig. <note>Sono inserte in questo esemplare le 38 belle tavole
+            del Kottero che lo rendono prezioso. Mar. dor. della Bibliot. di Malborough.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28590" n="1920" corresp="dcl:1gs">
+      <label>1920.</label>
+      <bibl><author>MEISNER</author>, <title>Thesaurus Philopoliticus hoc est emblemata moralia
+            politica figuris aeneis incisa</title>, <pubPlace>Francf.</pubPlace>
+         <date>1624</date>, 25. <note>Opera copiosissima divisa in 5 parti che contiene presso a 300
+            tavole illustrate in latino e in tedesco. Esemp. della Bibl. Malborough.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28596" n="1921" corresp="dcl:5cj">
+      <label>1921.</label>
+      <bibl><author>MENESTRIER Claude François</author>, <title>Histoire du Roi Louis le Grand par
+            les médaiìles, emblémes, dévises etc. recueillies et expliquées</title>,
+            <pubPlace>Paris</pubPlace>
+         <date>1689</date>, in fol. figurato. <note>Opera eseguita con eleganza e con lusso di tipi
+            e di bulino. Le medaglie sopra tutto sono di una nitidezza grande od espresse a contorno
+            da G.B. Nolin uno dei migliori allievi di Poilly. Sevin intagliò gli emblemi e le altre
+            stampe. In totale i fogli del libro ascendono a sessanta due e sono tutti intagliati in
+            rame, compreso il frontespizio, la dedica e un avvertimento al fine, giacché il testo
+            sta espresso in caratteri d’ intaglio in ciascuna lamina.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28620" n="1924" corresp="dcl:5sm">
+      <label>1924.</label>
+      <bibl><author>Le MOYNE P. de la compagnie de Jesus</author>, <title>De l’art <pb type="cico"
+               n="327"/> des dévises, avec divers recueils de dévises du même auteur</title>,
+            <pubPlace>Paris</pubPlace>, chez Cramoisy, <date>1666</date>, in 4 f. <note>Con un bel
+            frontespizio di le Pautre e 191 tavole, delle quali un gran numero è intagliato da
+            questo incisore.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28627" n="1925" corresp="dcl:35x">
+      <label>1925.</label>
+      <bibl><author>ORO Apolline Niliaco</author>, <title>Delli segni hierogliphici tradotto in
+            lingua volgare da M. Pietro Vassoli da Fivizano</title>, in
+         <pubPlace>Vinegia</pubPlace>, presso <publisher>Gab. Giolito de Ferrari</publisher>,
+            <date>1547</date>, in 8. <note>Edizione elegante.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28664" n="1931" corresp="dcl:jnv">
+      <label>1931.</label>
+      <bibl><author>PARVUS Mundus</author>. <bibl>Vedi <title>Microcosmus</title></bibl>. </bibl>
+   </item>
+   <item xml:id="c1d1e28702" n="1936" corresp="dcl:wnt">
+      <label>1936.</label>
+      <bibl><author>PIROLI Tommaso</author>, <title>Raccolta di dodici Virtù personificate</title>,
+         dipinte coi disegni di Raffaello d’Urbino nella sala detta di Giulio Romano al Vaticano,
+         incise all’acqua forte da Tommaso Piroli, <pubPlace>Roma</pubPlace>, presso <publisher>il
+            suddetto a strada Gregoriana</publisher>, tav. XII etc., in fol. </bibl></item>
+   <item xml:id="c1d1e28715" n="1938" corresp="dcl:z4w">
+      <label>1938.</label>
+      <bibl><author>PITTONI Giovan Battista pittore vicentino</author>, <title>Altro esemplare con
+            titolo imprese nobili ed ingegnose etc. etc.</title>, in <pubPlace>Venezia</pubPlace>,
+         presso <publisher>Girolamo Porro</publisher>, <date>1578</date>. <note>Nel frontespizio non
+            è ricordato il nome del Pittoni, ma <pb type="cico" n="329"/> nell’avviso ai lettori sta
+            espresso dall’editore, che unì queste tavole ad altre di molti ingegni pellegrini, ec.
+            Le tav. sono 72 compreso il frontespizio.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28782" n="1948" corresp="dcl:dcj">
+      <label>1948.</label>
+      <bibl><author>RUSCELLI Jeronimo</author>, <title>Le imprese illustri coll’aggiunta di altre
+            imprese riordinato e corretto</title>, <pubPlace>Venezia</pubPlace>, presso
+            <publisher>il Franceschi</publisher>, <date>1580 a 1583</date>, in 4, fig. <note>Questo
+            quantunque abbia una data anteriore, per esser logore le tavole mostra dì essere
+            stampato dopo l’edizione seguente ed essere una edizione contrafatta.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28795" n="1950" corresp="dcl:tz7">
+      <label>1950.</label>
+      <bibl><author>SAAVEDRAE Didaci Faxardi</author>, <title>Idea principis christiano
+            politici</title>, <date>1749</date>, in 8, fig. <note>Edizione accurata ed elegante di
+            oltre 600 pagine con 103 tavole intagliate in rame. Mancante del frontespizio, sebbene
+            sia bello e ben conservato esemplare, colle medesime tavole della seguente, che non
+            hanno altro merito che tuta certa accuratezza.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28813" n="1953" corresp="dcl:290">
+      <label>1953.</label>
+      <bibl><author>SANCTII Brocensis Francisci</author>, <title>In Andreae Alciati emblemata
+            comment.</title>, <pubPlace>Lugduni</pubPlace>, ap. <publisher>Rovil.</publisher>,
+            <date>1573</date>, in 12. <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+         <note>Sono in quest’edizione impresse le 211 tavole in legno dell’Alciato che videro la
+            luce negli emblemi del 1564.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28825" n="1954" corresp="dcl:fp1">
+      <label>1954.</label>
+      <bibl><author>SCARLATTI D. Ottavio</author>, <title>L’huomo e sue parti figurato e simbolico
+            raccolto e spiegato con figure, simboli, emblemi, geroglifici</title>, in due libri
+         distinto con addizioni e tavole copiosissime, <pubPlace>Bologna</pubPlace>
+         <date>1684</date>, in fol. fig. <note>Domenico Bonavera intagliò le copiose tavole, e il
+            frontespizio di quest’opera voluminosa di circa 800 pagine poco dissimile da quella del
+            Picinelli: e della medesima mediocre importanza.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28832" n="1955">
+      <label>1955.</label>
+      <bibl><author>SCHOONHOVII Florentii</author>, <title>Emblemata partim moralia, partim etiam
+            civilia etc.</title>, <pubPlace>Goudae</pubPlace>
+         <date>1618</date>, in 4, p. figurato. <note>Sono 74 emblemi di buono ed accurato intaglio
+            oltre il ritratto dell’autore ed il frontespizio, prima ed elegante edizione.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28856" n="1959">
+      <label>1959.</label>
+      <bibl><author>SPERLING</author>, <title>Judicium Paridis XX emblematibus illustratum cum
+            germanis et latinis versibus</title>, <pubPlace>Aug. Vindel.</pubPlace>, sine anno, in
+         fol. <note>Sono 30 tavole di bell’intaglio con illustrazioni latine tedesche.</note>
+         <pb type="cico" n="332"/>
+      </bibl></item>
+   <item xml:id="c1d1e28864" n="1960">
+      <label>1960.</label>
+      <bibl><author>TAFEREEL (van)</author>, <title>Sinne-mal Zeeusche Nachtegael ende des self
+            dryderley gesang tot.</title>, <pubPlace>Rotterdam</pubPlace>
+         <date>1632</date>, in 12, fig. <note>Libretto per traverso dì favole e poesie con vari
+            emblemi figurati ec.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28877" n="1962" corresp="dcl:zc4">
+      <label>1962.</label>
+      <bibl><title>SYMBOLA divina et humana pontificalis</title>, imperatorum, regum, tomo I,
+            <date>1601</date>. — <bibl><title>Symbola varia diversorum principum</title>, t.
+            secondo, <date>1602</date>, e il terzo tomo <date>1603</date>, in fol.</bibl>
+         <note>Anselmo di Bordt compose le illustrazioni del 3 volume; ed Egidio Sadeler intagliò le
+            numerosissime tavole di quest’opera legata in un solo volume.</note>
+      </bibl></item>
+   <item xml:id="c1d1e28883" n="1963" corresp="dcl:dk1">
+      <label>1963.</label>
+      <bibl><title>SYMBOLA divina et humana pontificum, imperatorum, regum</title>: accessit brevis
+         et facilis Isagoge Jac. Typotii, <date>1666</date>, in 12, fig., senza luogo. <note>Con più
+            di 370 emblemi intagliati in rame.</note>
+         <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+      </bibl></item>
+   <item xml:id="c1d1e28895" n="1964">
+      <label>1964.</label>
+      <bibl><title>SYMBOLA divina et humana pontificum, imperatorum, regum, ex museo Octavii de
+            Strada Civis Romani </title>, <pubPlace>Arn.</pubPlace>
+         <date>1666</date>, in 12, fig. </bibl></item>
+   <item xml:id="c1d1e29069" n="1986">
+      <label>1986.</label>
+      <bibl><author>BAUR Jo. Wilhelmi</author>, <title>Le Metamorfosi d’Ovidio col frontesp. in
+            tedesco</title>, <pubPlace>Vienne d’Austrie</pubPlace>
+         <date>1641</date>, in 4. <note> Edizione originale in 150 tavole di freschissimo e
+            bellissimo intaglio all’acqua forte M. 107. </note>
+      </bibl></item>
+   <item xml:id="c1d1e29075" n="1987" corresp="dcl:bg7">
+      <label>1987.</label>
+      <bibl><author>BAUR Jo. Wilhelmi</author>, <title>Pub. Ovidii Nasonis Metamorphoseon</title>,
+            <pubPlace>Augspurg</pubPlace>
+         <date>1709</date>, in fol. obl. <note>Queste sono le medesime 150 tavole da questo
+            valentissimo intagliatore prodotte nella p. edizione e in questa ristampate e non
+            riconoscibili per essere assai logore; a fronte di ciascuna sta il testo in lingua
+            tedesca. </note>
+      </bibl></item>
+   <item xml:id="c1d1e29096" n="1990">
+      <label>1990</label>
+      <bibl><author>BIBLIA ad vetustissima exemplaria nunc recens castigata</author>,
+            <title>Romaeque revisa</title>, <pubPlace>Venetiis</pubPlace>, apud Junctas in
+            fol.<note> Vedi per le Biblie. Biblia Pauperum: Vita et Passio: Veteris Testamenti
+            Stockmann: Schellemberg Histoire du V. et du N. Testament. Bibl. de Mortier. Luyken:
+            Imagines veteris Testamenti: Ulrich Kraussen: Historiarum <fw type="foot"/>
+            <pb type="memofonte"/>
+            <fw type="head"/> Passeo Crispino Lib. Gen. </note>
+      </bibl></item>
+   <item xml:id="c1d1e29114" n="1992">
+      <label>1992.</label>
+      <bibl><title>BIBLIA Pauperum. </title><note> Noi crediamo di non dovere con diverso nome
+            intitolare il seguente libretto di cui i bibliografi ci lasciano oscuri, e che non
+            troviamo enumerato nella classe cui appartiene se non dal eig. Ab. P. Zani nella parte
+            a. del 1 Voi. della sua Enciclopedia metodica di Belle Arti, citandone due esemplari da
+            lui veduti, ma imperfetti. Il nostro esemplare è completo e ben conservato ed un altro
+            ne fu veduto da noi in Londra alla vendita dei libri rari del Duca di Malborough.
+            Convien credere che il Bar. Heinecken e il sig. Ottley non ne avessero sentore se ne
+            tacquero nelle dottissime e preziose loro opere. Il titolo è il seguente. <pb
+               type="cico" n="339"/> Opera nova contemplativa per ogni fedel cristiano, la quale
+            tratta delle figure del Testamento Vecchio: le quali figure sono verificale nel
+            Testamento Nuovo: con le sue exposizioni: et con el detto de li propheti sopra esse
+            figure: siccome legenda troverete: et nota che a ciaschuna figura del Testamento nuovo
+            trovami dita dil Testamento vecchio: le quali sono affigurate a quelle del nuovo, et
+            sempre quella del nuovo sarà posta nel meggio di quelle dita del vecchio: cosa
+            bellissima da intendere a chi se dilectano de la sacra Scrittura: nuovamente stampata.
+            Il titolo è in quadrato in una cornice nera con ornamenti chiari a maniera di ciffre.
+            Comincia coi tre medesimi i soggetti della Biblia Pauperum, Gedeone genuflesso coll’elmo
+            in capo e le mani giunte, l’Annunciata e il colloquio d’Eva col serpente: e sono appunto
+            40 soggetti trattati nello stesso modo a tre a tre, formanti il numero di 120 tavole. La
+            prima tavola di ciascun soggetto e la terza hanno le loro iscrizioni, come la seguente
+            ch’è nella tavola di Gedeone: Leggesi in lo libro de Indici al sexto Ca. che Gedeone
+            dimando a Dio signore vittoria per la rugiada irigada sopra la luna: questa significava
+            et figurava la tergine Maria gloriosa senza compitane intravedala per infusione dello
+            Spirito Santo: e l’altra che sta alla terza tavola del primo soggetto, la quale figura
+            il colloquio di Eva: Leggesi in Genesi al tenia va, che il signore Dio disse al
+            serpente: tu caminerai sopra el petto tuo; et etiam leggisi che la donna romperà il capo
+            del serpente: et tu serpente sarai insidiato dal suo calceo: Certo questo fu adimpito in
+            la nuntiatione della gloriosa Vergine Maria. Nella tavola poi che resta fra la prima e
+            terza di ognuno di questi 40 soggetti stanno come in due arcate o nicchie in mezzi busti
+            i Profeti, leggendosi nelli due primi De Hieremia al 31 il Signore ha creato una cosa
+            nova sopra la terra; la donna ha circundato l’intorno: De Ezechiele 44: Questa porta
+            farà serrati et non se aprirà. Così procede col med. ordine sino al termine ove
+            s’incontrano i tre soggetti come sono descritti dai bibliografi nelle altre Bibliae
+            Pauperum più antiche. Nell’ultima carta contornata, come abbiamo descritto il
+            frontespizio, è stampato opera di Giovanni Andrea Vavassore ditto Vadagnino: Stampata
+            novamente nella inclita città diVinegia. Laus Deo. Dopo trovasi un’altra carta con una
+            Madonna seduta in trono con due Angeli che la incoronano: tiene il Bambino in piedi
+            sulle ginocchia e due angeli laterali suonano. Le stampe sono di bella esecuzione, e
+            provengono da disegni di diversi maestri, alle quali non può assegnarsi una data più
+            antica del 1510 ovvero 12, giacché alcuna (siccome avvertì l’Ab. Zani) è presa dalla
+            passione di Alberto Durero e fra le altre poi esattissimamente quella ove N. S. scaccia
+            i profanatori del tempio, che dal maestro tedesco si pubblicò nel 1509. Alcune altre poi
+            sono rozze ed alcune sembrano provenire possino da’ bei disegni dei Bellini, del
+            Carpazio <pb type="cico" n="340"/> dello Squarcione o del Montagna come probabilmente
+            sarà. Questo Vadagnino pubblicò diversi anni dopo anche la vita di Esopo volgarizzata
+            dal Tuppo.</note>
+         <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+      </bibl></item>
+   <item xml:id="c1d1e29128" n="1993" corresp="dcl:knx dcl:wjz">
+      <label>1993.</label>
+      <bibl><author>DE BIE Jacques</author>, <title>Les vrais portraits des rois de France augmentés
+            de nouveaux portraits et des vies des rois par de Costes</title>,
+            <pubPlace>Paris</pubPlace>
+         <date>1689</date>, in fol. pic. figurato.<note> Giunge quest’opera a Luigi XIII al quale è
+            intitolata. Le tavole sono appena mediocri.</note>
+      </bibl></item>
+   <item xml:id="c1d1e29153" n="1997" corresp="dcl:pjw">
+      <label>1997.</label>
+      <bibl><author>BOISSARDI Jani Jacobi</author>, <title>Veri ritratti degl’imperatori turchi e
+            principi persiani da Osmano fino a Maometto II, estratti dalle medaglie col ristretto
+            delle loro vite in versi di Giorgio Greblinger</title>, <pubPlace>Francf.</pubPlace>,
+         per <publisher>Gio. Amon</publisher>, <date>1648</date>. <note>Sono le tavole stesse del
+            precedente. </note></bibl></item>
+   <item xml:id="c1d1e29165" n="1999">
+      <label>1999.</label>
+      <bibl><author>BONARROTI Michel Angelo</author>, <title>Profeti, Sibille ed altre figure da lui
+            disegnate</title>, incise da Adamo Mantovano, tav. 73, in 4. <note>Esemplare di prima
+            nitidezza e freschezza. Oltre le tavole figurate vedesi nel frontespizio una Cartella
+            intagliata colla Iscrizione: Michael Angelus Bonarotus pinxit; Adam sculptor mantuanns
+            incidit.</note>
+      </bibl></item>
+   <item xml:id="c1d1e29178" n="2001">
+      <label>2001.</label>
+      <bibl><author>BOSSI Benigno milanese prof. nell’Accad. di Parma</author>, <title>Raccolta di
+            disegni originali di Fran. Mazzola detto il Parmigiano, tolti dal gabinetto del C.
+            Sanvitali</title>, <pubPlace>Parma</pubPlace>
+         <date>1772</date>, con qualche altra stampa tratta da disegni originali: sono tavole 37. —
+            <bibl>Aggiuntavi: <title>una raccolta di teste inventate, disegnate, ed incise dallo
+               stesso</title>, <pubPlace>Parma</pubPlace>, presso <publisher>l’autore</publisher>:
+            sono tav. 17 nelle quali sono intagliate 39 teste.</bibl> — <bibl>Aggiuntevi: altre 8
+            tavole tratte da diversi autori.</bibl>
+         <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/> —<bibl> Aggiuntevi: <title>Fisonomie possibili parte 1</title>,
+               <date>1776</date>, tav. 8.</bibl>
+         <note>In tutto il volume è di tavole 70 intagliate con grazia all’acqua forte.</note>
+      </bibl></item>
+   <item xml:id="c1d1e29190" n="2002" corresp="dcl:tjp">
+      <label>2002.</label>
+      <bibl><author>CALLOT Jacques</author>, <title>Les images de tous les Saints et Saintes de
+            l’année suivant le Martirologe Romain, mises en lumiere par Israel Henri et dédiées à
+            Monsigneur l’Eminentissime Cardinal Duc de Richelieu</title>, à
+            <pubPlace>Paris</pubPlace>
+         <date>1636</date>, in f. <note>Compreso il frontespizio, che presenta le armi del duca e la
+            prima carta dove sono tutti Santi ricevuti in Paradiso, vi sono 490 soggetti intagliati
+            a quattro in tante composizioni <pb type="cico" n="342"/> racchiuse da una forma
+            elittica. Esemp. in mar. freschissimo.</note>
+      </bibl></item>
+   <item xml:id="c1d1e29307" n="2018">
+      <label>2018.</label>
+      <bibl><title>CYMBALUM Mundi</title>. <bibl>Vedi <author>Perrier</author></bibl>.
+      </bibl></item>
+   <item xml:id="c1d1e29350" n="2024">
+      <label>2024.</label>
+      <bibl><author>DUVIVIER</author>, <title>12 Vedute all’acqua forte dei contorni di Baden presso
+            Vienna</title>, prese nella <pubPlace>Valle di S. Elena</pubPlace>, in fol. p. obl.
+      </bibl></item>
+   <item xml:id="c1d1e29446" n="2038">
+      <label>2038.</label>
+      <bibl><author>GROTESQUES</author>, <title>Statues, cartouche d’après differenti
+            maîtres</title> in fol. p. <note>Questa è una miscellanea di 179 tavole coi più begli
+            ornamenti de’ principali gabinetti di Francia e anche d’Italia inventati da Simon Vovet,
+            da Ducerceau, dai Mitelli, dal Rosso Fiorentino, da Champagne, da Raffaello, intagliate
+            da buoni artefici come Dorigny, Poilly, B. David, Ciartres ec.</note>
+      </bibl></item>
+   <item xml:id="c1d1e29470" n="2041">
+      <label>2041.</label>
+      <bibl><title>HISTOIRE des Yncas Rois du Perou traduite de l’espagnol de l’Ynca Garcilasso de
+            la Vega: on a joint à cette edition l’histoire de la conquête de la Floride par le même
+            auteur avec figures dessinées par B. Picart le Romain</title>,
+            <pubPlace>Amsterdam</pubPlace>
+         <date>1787</date>, vol. 2, in 4, gr. <note>Sono 18 le belle stampe, che rendono preziosa e
+            piacevole questa edizione, la quale è utilissima per la rappresentazione de’ costumi di
+            quelle nazioni.</note>
+         <pb type="cico" n="350"/>
+      </bibl></item>
+   <item xml:id="c1d1e29509" n="2046">
+      <label>2046.</label>
+      <bibl><title>HORAE intemerata Dei Genitricis firginis Maria; secundum usum Romanae Ecclesiae
+            ossia officia quotidiana sive Horae B. M. brevi pulcherrimoque stilo atque ordine
+            compositae, secundum usum Romanae Ecclesiae: cum pluribus memoriis et devotissimis
+            orationibus illis annexis. Finem sumpsisse cernens o lector devotissime, Deo et sui
+            scorregnantibus gratias age, Impressoremque Thielmannum Kerver (Almae universitatis
+            Parisiensis librarium juratum in Magno Vico o Jacobi ad Signum Cratis commorantem)
+            lauda: qui hoc opus Parisiis impressit. Anno ab incarnatone Dei millesimo quingentesimo
+            septimo, die prima mensis Februarii.</title>
+         <note>Questi due scritti l’uno a tergo dell’altro stanno nell’ultimo fogli di stampa. I
+            fogli sono 152 impressi da ciascun lato con un contorno istoriato e figurato
+            indipendentemente dalle tavole principali che sono meno belle dei contorni. È
+            incredibile la varietà delle storie che sono espresse in questi lavori in legno: gli
+            esemplari più accreditati sono in pergamena e miniati. Kerver ristampò questo ufficio
+            più volte e siccome questa è una delle prime impressioni, o forse la prima, cosi le
+            stampe hanno il pregio della freschezza originale senza aiuto del pennello. Esemplare di
+            prima legatura e conservazione.</note>
+      </bibl></item>
+   <item xml:id="c1d1e29618" n="2061">
+      <label>2061.</label>
+      <bibl><author>LUCINI Ant. Fr.</author>, <title>Disegni della guerra, assedio ed assalti dati
+            dall’armata turchesca all’Isola di Malta, l’anno 1565</title>,
+            <pubPlace>Bologna</pubPlace>
+         <date>1631</date>, in fol. M. 105. <note>Sono 16 tavole intagliate con valore compreso il
+            frontespizio colle dichiarazioni sotto ciascuna.</note>
+      </bibl></item>
+   <item xml:id="c1d1e29642" n="2065">
+      <label>2065.</label>
+      <bibl><author>MERIAN Mathieu, ou ses Héritiers</author>, <title>La Dance des Morts telle qu’on
+            la voit depeinte dans la célèbre Ville de Basle enrichie de tailes douces d’après
+            l’original d’Holbein et traduite de l’Allemand en françois par les soins des
+            Héritiers</title>, <pubPlace>Berlin</pubPlace>
+         <date>1698</date>, in 8, fig. <note>Le 46 stampe sono riunite ai singolari dialoghi, la cui
+            esposizione è fatta in versi; e in fine avvi la lettera di Enea Silvio Piccolomini che
+            rende interessante quest’opera. <bibl>Vedi <author>Holbein</author>.</bibl></note> —<bibl>
+            <author>MITELLI Gius. M.</author>
+            <bibl>Vedi <author>Caracci An.</author>
+               <title>L’Ènea Vagante</title>.</bibl></bibl>
+         <pb type="cico" n="356"/>
+      </bibl></item>
+   <item xml:id="c1d1e29657" n="2067">
+      <label>2067.</label>
+      <bibl><title>MONTE (Libro del) di Dio e del Monte delle Orazioni et Scala del Paradiso
+            devotissimo et Spirituale</title>. Composto dal divoto et docto Servo di Gesù Cristo
+         Frate Antonio da Siena povero <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/> Gesuato Vescovo di Fuligno. Impresso nell’inclita Cipta di
+            <pubPlace>Firenze</pubPlace> per <publisher>Ser Lorenzo de’ Morgiani et Gio. Thodesco de
+            Maganza</publisher> a 20 di Marzo <date>1491</date>. <note>Le tre tavole che qui si
+            veggono intagliate in legno sono imitazioni delle tre in rame, che stanno nella molto
+            più rara e pregiata edizione del 1477.</note>
+      </bibl></item>
+   <item xml:id="c1d1e29718" n="2075">
+      <label>2075.</label>
+      <bibl><author>ORTELIO Abrahamo</author>, <title>Theatro del Mondo</title>.<bibl>Vedi tra le
+               <title>Guide e Illustrazioni</title></bibl>. </bibl></item>
+   <item xml:id="c1d1e29755" n="2081">
+      <label>2081.</label>
+      <bibl><author>PERRIERS Bonaventurae</author>, <title>Cymbalum mundi ou dialogues satiriques
+            sur differents suject par Bon. Perriers valet de Chambre de Marguerite de Valois, avec
+            une lettere critique par Prosper Marchand libraire</title>, <pubPlace>Amst.</pubPlace>
+         <date>1711</date>, petit en 12, fig. <note>La prima edizione del 1537 di questo libercolo
+            si è resa introvabile e forse non se ne conoscono dai bibliografi due esemplari.
+            L’edizione da noi posseduta rende un’idea dell’opera e del motivo della soppressione dei
+            primi esemplari, che probabilmente avvenne soltanto per alcune allusioni a personaggi
+            alti e potenti. Le cinque bellissime stampe di B. Pickard danno anche a quest’edizione
+            un qualche pregio.</note>
+         <pb type="cico" n="359"/>
+      </bibl></item>
+   <item xml:id="c1d1e29763" n="2082">
+      <label>2082.</label>
+      <bibl><author>PERRIERS</author>, <title>CONTES et Nouvelles et Joyeux dévis</title>,
+            <pubPlace>Amst.</pubPlace>
+         <date>1711</date>, in 12. Avec des observationes à la fin sur le Cymbalum Mundi.
+            <note>Queste osservazioni tendono a giustificare ed interpretare alcuni luoghi della
+            satira.</note>
+      </bibl></item>
+   <item xml:id="c1d1e29819" n="2090">
+      <label>2090.</label>
+      <bibl><title>RACCOLTA dei ritratti dei Conti del Tirolo.</title>
+         <note>Sono 26 tavole compreso il frontespizio con marca L. A. Le dichiarazioni sono in
+            tedesco. M. 100.</note></bibl></item>
+   <item xml:id="c1d1e29825" n="2091" corresp="dcl:45x">
+      <label>2091.</label>
+      <bibl><author>RADERO Mattheo</author>. <bibl>Vedi <title>Bavaria
+      Sancta</title>.</bibl></bibl></item>
+   <item xml:id="c1d1e29876" n="2098">
+      <label>2098.</label>
+      <bibl><author>ROSA Salvator</author>, <title>Has eludendi otii Carolo Rubeo singularis
+            Amicitiae pignus D. D. D.</title>
+         <note>Questo libro in foglio è composto dai primi 16 fogli contenenti 62 figure di soldati,
+            in seguito alle quali vengono altri 3 fogli con 6 stampe di fiumi e deità marine; 617
+            altri fogli di opere di gran composizione in tutto 36 fogli. Opera di questo autore
+            completa.</note>
+      </bibl></item>
+   <item xml:id="c1d1e29888" n="2100">
+      <label>2100.</label>
+      <bibl><author>RUBENS P. P.</author>, <title>I dodici ritratti di filosofi presi dall’antico da
+            lui disegnati e intagliati da P. Ponzio, da H. Withouc, da Bolsvert e da Vostermans,
+            fra’ quali due sono duplicati, in fol.</title>
+         <date>1638</date>. </bibl></item>
+   <item xml:id="c1d1e29894" n="2101">
+      <label>2101.</label>
+      <bibl><author>SADELER Egidius</author>, <title>I 12 Cesari dipinti da Tiziano intagliati in 12
+            tavole in fol. accompagnati <pb type="cico" n="362"/> dalle 12 mogli dei Cesari incise
+            dallo stesso, ma da altri disegni</title>; sotto ciascuna stanno quattro distici latini,
+            <pubPlace>Paris</pubPlace>, chez <publisher>la V. de Cherau</publisher>. </bibl></item>
+   <item xml:id="c1d1e29901" n="2102">
+      <label>2102.</label>
+      <bibl><author>SADELER Iustus</author>, <title>Duodecim Cesarum qui primi Romae imperarunt
+            effigies, cum Ausonii in eosdem Tetrasticis</title>, <pubPlace>Venetiis</pubPlace>
+         <date>1608</date>, in 4. <note>Incisioni singolari con molta bizzarria dì finissimo
+            intaglio nelle celate, di cui hanno coperta il capo.</note>
+      </bibl></item>
+   <item xml:id="c1d1e29993" n="2115">
+      <label>2115.</label>
+      <bibl><author>TESTELIN L.</author> et Leonis Ferdinand, <title>Raccolta di fregi formali da’
+            genietti intrecciati con festoni e ghirlande</title>. Intagliati da L. Ferdinand sui
+         disegni di Testelin ed altri pubblicati da <pubPlace>Mariette</pubPlace>. <bibl>Aggiuntivi
+            alcuni disegnati ed incisi da Giulio Carpioni pubblicati in <pubPlace>Padova</pubPlace>
+            da <publisher>Mattia Cadorin detto Bolzetta</publisher>. In tutto 19 stampe con vario
+            gusto e bella maniera eseguite.</bibl>
+      </bibl></item>
+   <item xml:id="c1d1e30042" n="2122">
+      <label>2122.</label>
+      <bibl><author>VAGNER Joseph</author>, <title>Dominicae Passionis Misteris aere incisa</title>,
+            <pubPlace>Venetiis</pubPlace>
+         <date>1778</date>. In 14 Stazioni con altre 87 tavole intagliate da vari maestri di
+         soggetti sacri, la più parte tavole di altari le più celebrate, in fol. figurato.
+      </bibl></item>
+   <item xml:id="c1d1e30054" n="2124">
+      <label>2124.</label>
+      <bibl><author>VALLI Antonio da Todi</author>, <title>Il canto degli augelli, dove si dichiara
+            la natura di sessanta sorte d’uccelli che cantano etc. con le loro figure e venti sorte
+            di caccia cavate dal naturale da Antonio Tempesti</title>, <pubPlace>Roma</pubPlace>
+         <date>1601</date>, in 4, fig. <note>Il frontespizio è figurato e sonovi 50 tavole in rame
+            colle illustrazioni. Alcune di queste tavole furono riprodotte nella uccelliera
+            dell’Olina. I libri, che servirono a’ piaceri della caccia, finirono spesso a
+            fanciullesco trastullo per l’amenità dei soggetti e vennero logorati senz’essere
+            riprodotti, motivo spe <pb type="cico" n="367"/> cialmente della loro rarità, oltre che
+            alcuni, siccome i due enunciati, tono eseguiti da buoni disegnatori.</note>
+      </bibl></item>
+   <item xml:id="c1d1e30060" n="2125">
+      <label>2125.</label>
+      <bibl><author>VANDYCK Antoine</author>, <title>Le cabinet de plus beaux portraits de plusieurs
+            Princes et Princesses, hom-mes illusrres, fameux peintres</title>. Ouvrage qui sert de
+         suppléoient au cabinet du farneux Vandyck. Im-priméeà Anverse.
+            <pubPlace>Amsterdam</pubPlace> chez<publisher>Mortier</publisher>
+         <date>1732</date> in fol. <note>Quarantasei ritratti, che trovatisi la più parte ripetuti
+            nelle opere precedenti e non di bella freschezza.</note>
+      </bibl></item>
+   <item xml:id="c1d1e30085" n="2128">
+      <label>2128.</label>
+      <bibl><author>VAVASSOBK Gio. Andrea ditto Vadagnino</author>. <title>Vedi Biblia
+            Pauperum.</title>
+      </bibl></item>
+   <item xml:id="c1d1e30091" n="2129">
+      <label>2129.</label>
+      <bibl><author>De la VEGA Garcilano</author>. <title>Vedi Histoiredes Yncas.</title>
+      </bibl></item>
+   <item xml:id="c1d1e30134" n="2136">
+      <label>2136.</label>
+      <bibl><title>VITA et miracula D. Bernardi Clarevallensis Ab. O <pb type="cico" n="369"/> pera
+            et industria Congreg Reg. Observantiae eiusdem Hispanianun aeneis formis
+            expressa</title>. Impensis Marcelli Clodii incidebatur, <pubPlace>Romae</pubPlace>
+         <date>1587</date>, in fol. Antonius Tempestinus invenit.</bibl>
+      <note>Sono queste 56 tavole, compreso il ritratto e il frontespizio, come viene indicato anche
+         dal Catalogo di Mariette. Molti intagliatori dei primi ebbero parte in questo lavoro.
+         Alcune tavole furono intagliate da Alberto Cherubini <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/> da Borgo S. Sepolcro, altre da Rafaello Guidi, che lavorò sullo stile de’
+         Caracci, altre da Filippo Galle e dal suo figlio Cornelio, che stava seco in quel tempo a
+         Roma e incominciava a intagliare. Opera eseguita con grandiosità di stile.</note>
+   </item>
+   <item xml:id="c1d1e30191" n="2143">
+      <label>2143.</label>
+      <bibl><title>RITRATTI d’illustri Italiani viventi</title>, <pubPlace>Padova</pubPlace>,
+         tipografia <publisher>Bettoni</publisher>, <date>1815</date>, in 4. <note>La prima di
+            queste due opere in ispecie, che progredisce al suo termine, comprende una serie di 60
+            preziosi ritratti intagliati e disegnati da’ primi artisti viventi, essendo le memorie
+            storione estese da’ più chiari letterati del secolo. </note>
+      </bibl></item>
+   <item xml:id="c1d1e30198" n="2144">
+      <label>2144.</label>
+      <bibl><author>De Vos Martino. </author> Vedi Oraculum anachoreticum, Vita, Passio et
+         Resurrectio Christi.</bibl></item>
+   <item xml:id="c1d1e30226" n="2147">
+      <label>2147.</label>
+      <bibl><author>BALDO Bernardino</author>, <title>Scamili impares vitruviani</title>, Augustae
+         vùidelicorum <date>1612</date> in 4.</bibl></item>
+   <item xml:id="c1d1e30277" n="2154">
+      <label>2154.</label>
+      <bibl><author>CORNEILLE</author>, <title>Dictionnaire universel des termes des arts et des
+            sciences de M. D. Corneille de l’Académie Française; novelle édition, vue, corrigée et
+            augmentée par M. ****</title>, <date>1731</date>, in fol. vol. 2. </bibl></item>
+   <item xml:id="c1d1e30304" n="2158" corresp="dcl:w25">
+      <label>2158.</label>
+      <bibl><title>Le DICTIONAIRE des arts et des sciences de M. D. C. de l’Académie Francaise.
+            Nouvelle édition revue, corrigée et augmentée par M. *** de l’ Académie Royale des
+            sciences </title>, <pubPlace>Paris</pubPlace>
+         <date>1745</date>, in fol., 2 vol. </bibl></item>
+   <item xml:id="c1d1e30322" n="2161">
+      <label>2161.</label>
+      <bibl><title>ENCICLOPEDIE ou dictionnaire des sciences, des arts et des métiers</title>, avec
+         le supplément, <pubPlace>Livourne</pubPlace>
+         <date>1770</date>, vol. 33, in fol. dei quali 12 volumi contengono le tavole.
+      </bibl></item>
+   <item xml:id="c1d1e30390" n="2171" corresp="dcl:jc3">
+      <label>2171.</label>
+      <bibl><author>ORLANDI Pellegrino Antonio</author>, <title>Abecedario Pittorico</title>,
+            <pubPlace>Venezia</pubPlace>, per <publisher>il Pasquali</publisher>, <date>1753</date>,
+         in 4. <note>Con molte aggiunte preziossisime e postille manoscritte di mano di Venanzio de
+            Pagave. Esemplare che appartenne alla Biblioteca Bianconi e poi Bossi; il quale ne aveva
+            fatto un estratto per le memorie degli artisti Milanesi che andava preparando.</note>
+         <bibl><author>ORSINI</author>. <bibl>Vedi <title>all’Art.</title>
+               <author>VITRUVIO</author>.</bibl></bibl>
+      </bibl></item>
+   <item xml:id="c1d1e30487" n="2184">
+      <label>2184.</label>
+      <bibl><author>AGLIETTI D. Francesco</author>, <title>Elogio dei Bellini</title>. <bibl>Vedi
+               <title>Orazioni</title></bibl>. </bibl></item>
+   <item xml:id="c1d1e30549" n="2193" corresp="dcl:njw">
+      <label>2193.</label>
+      <bibl><author>BAGLIONE Giovanni Romano</author>, <title>Breve compendio della vita e morte di
+            S. Lazzaro monaco ed insigne pittore</title>, <pubPlace>Roma</pubPlace>
+         <date>1715</date>, in 16. </bibl></item>
+   <item xml:id="c1d1e30586" n="2198">
+      <label>2198.</label>
+      <bibl><author>BALDINUCCI</author>, <title>La medesima vita. Edizione posteriore contraffatta
+            con altri caratteri portante la stessa data, alla quale manca il ritratto del
+            Bernino.</title>
+         <note>Sebbene vi siano le stesse tavole, molti contrasegni fanno <pb type="cico" n="379"/>
+            conoscere la contraffazione eseguita verso la meta del XVIII secolo, ma sul frontespizio
+            si noti che dopo il nome Gio. vi sono due punti, e nell’originale un solo, e ove dicesi
+            nella stamperia a è minuscola e nella contraffazione è maiuscola; nell’originale sta un
+            vaso di fiori, mentre nella seconda edizione è una cestella.</note>
+      </bibl></item>
+   <item xml:id="c1d1e30610" n="2202">
+      <label>2202.</label>
+      <bibl><author>BARTHOLOMAEI Senensis Cartusiani</author>,<title> Vita B. Stephani Maconi
+            Senensis Cartusiani</title>, <pubPlace>Senis</pubPlace>
+         <date>1626</date>, in 4. <note>Libro di nessun pregio, ove però trovansi alcune traccie per
+            le fabbriche e i monumenti esistenti in alcune antiche certose.</note>
+      </bibl></item>
+   <item xml:id="c1d1e30629" n="2205">
+      <label>2205.</label>
+      <bibl><author>BARUFFALDI</author>, <title>Memorie dei pittori ferraresi</title>. Manoscritto
+         inedito in fol. <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+         <note>Preziosissimo per le interessantissime notizie inedite e per una quantità di aneddoti
+            d’arte non conosciuti e utilissimi per la storia delle medesime.</note>
+      </bibl></item>
+   <item xml:id="c1d1e30678" n="2212">
+      <label>2212.</label>
+      <bibl><author>BIAGI Avvocato</author>, <title>Elogio di Paolo Cagliari</title>, <bibl>Vedi
+               <title>Orazioni.</title></bibl>
+      </bibl></item>
+   <item xml:id="c1d1e30690" n="2214">
+      <label>2214.</label>
+      <bibl><author>BIANCONI Gio. Lodovico</author>, <title>Lettere sopra il libro del Crespi
+            intitolato: tomo terzo della Felsina Pittrice</title>, <pubPlace>Milano</pubPlace>
+         <date>1802</date>, in 8, fig. <note>Queste lettere sono anche impresse nei quattro volumi
+            delle opere del Bianconi che volle farne tirare alcuni esemplari a parte. Tendono
+            particolarmente a giustificare il merito di Ercole Lelli depresso negli scritti del
+            Canonico Crespi per impulso di vendetta privata. Trovatisi nel libro alcuni ritratti,
+            che sono oggetto di discussione e di critica.</note>
+         <pb type="cico" n="381"/>
+      </bibl></item>
+   <item xml:id="c1d1e30856" n="2238" corresp="dcl:rrf dcl:f89">
+      <label>2238.</label>
+      <bibl><author>CICOGNARA Leopoldo</author>, <title>Dell’origine dell’accademie</title>.
+         Orazione ed elogi di Tiziano, di Giorgione, di Palladio. <note>Queste quattro operette
+            vedile nelle orazioni recitate nelle distribuzioni de’ premi veneti.</note>
+      </bibl></item>
+   <item xml:id="c1d1e30977" n="2255">
+      <label>2255.</label>
+      <bibl><author>DIEDO Antonio</author>,<title> Elogio del professore Gio. Antonio Selva
+            architetto</title>, <pubPlace>Venezia</pubPlace>
+         <date>1819</date>, M. 80. <note>Col ritratto dello stesso in fronte.</note>
+      </bibl></item>
+   <item xml:id="c1d1e31059" n="2267" corresp="dcl:2w3">
+      <label>2267.</label>
+      <bibl><title>FIORI poetici a Francesco Petrarca in occasione che gli fu eretto nel Duomo di
+            Padova il monumento dallo scultore Rinaldo Rinaldi per cura del canonico Barbò da
+            Soncin</title>, <pubPlace>Padova</pubPlace>
+         <date>1819</date>, in 8. </bibl></item>
+   <item xml:id="c1d1e31065" n="2268">
+      <label>2268.</label>
+      <bibl><author>GAMBA Bart.</author>, <title>Elogio di Luigi Cornaro</title>. <bibl>Vedi
+               <title>Orazioni</title>.</bibl>
+      </bibl></item>
+   <item xml:id="c1d1e31102" n="2274">
+      <label>2274.</label>
+      <bibl><author>GENNARI Lorenzo</author>, <title>Diverse composizioni in lode della Didone di
+            Gio. Francesco Barbieri Centese</title>, da lui dedicate a Monsig. Furietti,
+            <pubPlace>Bologna</pubPlace>
+         <date>1632</date>, in 4, pic. <note>Con frontespizio graziosamente figurato.</note>
+      </bibl></item>
+   <item xml:id="c1d1e31219" n="2291">
+      <label>2291.</label>
+      <bibl><author>HUBER et Rost</author>, <title>Manuel des curieux et des amateurs de l’art,
+            contenant une notice abrégée des principaux graveurs et un catalogue raisonné de leurs
+            meilleurs ouvrages</title>, <pubPlace>Zuric</pubPlace>
+         <date>1797 a 1804</date> vol. VIII, in 8. <note>Rilegata in quattro. Opera utile, comoda e
+            piena di cognizioni per le stampe.</note>
+      </bibl></item>
+   <item xml:id="c1d1e31256" n="2297" corresp="dcl:frx">
+      <label>2297.</label>
+      <bibl><title>LE giustissime lagrime della pittura e della poesia pubblicate negli apparati
+            funebri di Pavia per i funerali di Luigi Scaramuccia perugino</title>,
+            <pubPlace>Milano</pubPlace>
+         <date>1681</date>, in 8. <note>Libretto raro a trovarsi.</note>
+      </bibl></item>
+   <item xml:id="c1d1e31473" n="2329">
+      <label>2329.</label>
+      <bibl><author>MORENI Canonico Domenico</author>, <title>Vita di Filippo di ser Brunellesco
+            architetto fiorentino scritta da Filippo Baldinucci</title>, con altra in fine di
+         anonimo contemporaneo scrittore, amendue per la prima volta pubblicate ed illustrate dal
+         Can. Moreni, <pubPlace>Firenze</pubPlace>
+         <date>1812</date>, in 8. <note>Sta unita all’altr’opera: Memoria intorno al risorgimento
+            delle arti in Toscana. Questo dotto e zelante cultore delle memorie stanche della sua
+            patria, è particolarmente benemerito alle arti.</note>
+      </bibl></item>
+   <item xml:id="c1d1e31555" n="2341">
+      <label>2341.</label>
+      <bibl><title>PAPILLON de la Ferté.</title>
+         <bibl>Vedi <title>la Ferté</title>.</bibl></bibl></item>
+   <item xml:id="c1d1e31705" n="2363">
+      <label>2363.</label>
+      <bibl><author>RIZZI Neuman</author>, <title>Elogio dei Vivarini</title>. <note>Vedi
+            Orazioni</note>. </bibl></item>
+   <item xml:id="c1d1e31810" n="2379">
+      <label>2379.</label>
+      <bibl><author>TESI Mauro</author>, <title>Sua vita: Vedi fra le opere prospettiche
+            Tesi.</title>
+      </bibl></item>
+   <item xml:id="c1d1e31847" n="2384" corresp="dcl:4sg">
+      <label>2384.</label>
+      <bibl><author>UGURGIERI Isidoro</author>, <title>Le pompe sanesi, ovvero relazioni degli
+            uomini e donne illustri di Siena e suo stato</title>, <pubPlace>Pistoia</pubPlace>
+         <date>1649</date>, vol. 2 in 8.<note> Opera molto pregievole ove trovanti curiose e
+            interessanti notizie anche dei primi restauratori delle arti in Italia che furono Pisani
+            e Sanesi.</note>
+      </bibl></item>
+   <item xml:id="c1d1e31886" n="2390">
+      <label>2390.</label>
+      <bibl><author>VASARI Giorgio</author>, <title>Le vite de’ pittori</title>,
+            <pubPlace>Firenze</pubPlace>
+         <date>1550</date>, in 5 vol. in fol. pic. <note>Edizione del Torrentino postillata dal P.
+            Sebastiano Resta. Era nelle Biblioteche Bianconi e Bossi. È singolare l’astio con cui il
+            Resta strapazza il Vasari in tutti quei punti nei quali da lui discorda. </note>
+      </bibl></item>
+   <item xml:id="c1d1e32105" n="2420">
+      <label>2420.</label>
+      <bibl><author>ABANO Petri</author>, <title>De phisionomia</title>, <pubPlace>Paduas</pubPlace>
+         <date>1474</date>, in 4.Il libro comincia: Incipit liber compilationis phisonomie a Petro
+         Padubanensi in civitate Parisiensi, cuius sunt tres particulae etc. E finisce: —
+            <bibl>Gratias altissimo Deo <date>anno Domini millesimo quadrigentesimo quarto</date>
+            hoc de phisonomia opus Petri Padubanensis per me <publisher>Petrum Manfer</publisher>
+            normannum <pubPlace>Paduae</pubPlace> impressura est. <note>Questa prima edizione è
+               indicata come rarissima dal Santander ed è composta di cinquanta foglietti di stampa
+               in caratteri rotondi e di bellissima forma senza segnature. Può quindi riputarsi come
+               il più singolare e pregevole libro di questa materia; magnifico
+            esemplare.</note></bibl>
+      </bibl></item>
+   <item xml:id="c1d1e32172" n="2430">
+      <label>2430.</label>
+      <bibl><author>CAMPER Pierre</author>, <title>On y a joint une dissertation physique sur les
+            differences réelles que presentent les traits du visage chez les hommes de differents
+            àges; sur le beau qui caractérise les statues autiques, et les pierres gravées</title>.
+         Suivie de la proposition d’une nouvelle méthode pour dessiner toutes sortes des têtes
+         humaines avec la plus grand sûreté, <pubPlace>Utrecht</pubPlace>
+         <date>1791</date>, in 4, fig., con 10 tavole. Opere dottissime e interessantissime.
+      </bibl></item>
+   <item xml:id="c1d1e32179" n="2431" corresp="dcl:rvm dcl:dkk">
+      <label>2431.</label>
+      <bibl><author>CARDANI H. Medici mediolanensis</author>, <title>Metoposcopia libris tredecm et
+            octiogentis faciei humana iconibus complexa, accedit melampodis de naevis corporis
+            tractatus graece et latine, nunc primum editiis</title>; interprete Claudio Martino
+         Laurenderio, <pubPlace>Lutetiae Parisiorum</pubPlace>
+         <date>1658</date>, in fol. <note>Libro dei meno comuni in questa materia.</note>
+         <pb type="cico" n="409"/>
+      </bibl></item>
+   <item xml:id="c1d1e32433" n="2468">
+      <label>2468.</label>
+      <bibl><author>SCOTI Michaelis</author>, <title>De procreatione et hominis physionomia</title>,
+            <date>1477</date>, in 8, sine loco. Comincia il volu <pb type="cico" n="414"/> me
+         coll’indice de capitoli che occupa tre foglietti, indi: Incipit liber physionomiae quem
+         compilavit Magister Michael Scotus ad preces D. Federici Romanorum imperatorii, Scientia
+         cuius est multum tenenda in secreto; e finisce Michaelis Scoti de procreatane et hominis
+         phisionomia opus feliciter finit, 1477. <note>Il Santander lo colloca fra i libri rari:
+            sono 88 foglietti di stampa in bei caratteri rotondi dei quali uno bianco: trovasi
+            spesso una mutilazione al capitolo 36 de notitia anguriorum.</note>
+      </bibl></item>
+   <item xml:id="c1d1e32439" n="2469">
+      <label>2469.</label>
+      <bibl><author>SCOTTO Michele</author>, <title>Fisionomia la qual compilò M. Mieli. Scoto a’
+            preghi di Federico Romano Imperatore huomo di gran scientia</title>,
+            <pubPlace>Venezia</pubPlace>, per <publisher>Francesco Bindoni</publisher>,
+            <date>1546</date>, in 8. <note>Questa versione italiana fu mutilata al capitolo 56 della
+            notizia degli auguri. <bibl>Vedi all’artic. <author>Alberti
+            Magni</author>.</bibl></note>
+      </bibl></item>
+   <item xml:id="c2d1e556" n="2476">
+      <label>2476.</label>
+      <bibl><author>AGINCOURT</author>. <title>Vedi Histoire de l’Art par les Monumens. Fra i libri
+            delle arti in generale</title>.</bibl></item>
+   <item xml:id="c2d1e568" n="2478">
+      <label>2478.</label>
+      <bibl><note>ANTIQUARIAN repertory intended to illustrate and preserve valuable remains of old
+            times (chiefly compiled by Grose, and Astle) </note>new edition with great additions,
+            <pubPlace>London</pubPlace><date> 1807 a 1809</date>, vol. 4, in 4. Ouvrage orne de 238
+         pl. </bibl></item>
+   <item xml:id="c2d1e581" n="2480" corresp="dcl:008">
+      <label>2480.</label>
+      <bibl><author>AUDRICHIO Everardo</author>, <title>Institutiones antiquariae</title>,
+            <pubPlace>Florentiae</pubPlace>
+         <date>1755</date>, in 4. <note>Sono buone instituzioni elementari per questo studio.</note>
+      </bibl></item>
+   <item xml:id="c2d1e710" n="2498">
+      <label>2498.</label>
+      <bibl><author>C. PLINII secundi</author>, <title>Historiae naturalis libri XXXVII</title>
+         <pb type="cico" n="5"/> quos interpretatione, et notis illustravit Joannes Harduinus. Ad
+         usum Delphini, <pubPlace>Parisiis</pubPlace>
+         <date>1723</date>, vol. 2, in fol. Vedi Durand David. </bibl></item>
+   <item xml:id="c2d1e718" n="2499" corresp="dcl:jfz">
+      <label>2499.</label>
+      <bibl><author>QUATREMERE de Quinci</author>,<title> Le Jupiter Olimpien. Vedi fra i Trattati
+            d’Arte.</title>
+      </bibl></item>
+   <item xml:id="c2d1e730" n="2501">
+      <label>2501.</label>
+      <bibl><author>Le SAGE</author>, <title>Atlas historique, cronologique, géographique, et
+            généalogique avec corrections, et additions, Florence, chez Molini et Landi</title>,
+            <date>1807</date>, in fol. atlant. <note>Il rapido colpo d’occhio che può portarsi su
+            tutta la storia in quest’opera la rende utilissima ad ogni studio d’antichità.</note>
+      </bibl></item>
+   <item xml:id="c2d1e736" n="2502">
+      <label>2502.</label>
+      <bibl><author>SALMASII Claudii</author>, <title>Plinianae exercitationes in Caji Julii Solini
+            Polyhistora: item Caji Julii Solini Polyhistor ex veteribus libris emendatus</title>,
+            <pubPlace>Parisiis</pubPlace>
+         <date>1629</date>, in fol., vol. 2. <note>Quest’opera è commendevole per la critica con cui
+            è scritta e per le nozioni d’antichità e di arti che vi si trovano, illustrando molti
+            luoghi di Plinio e di Vitruvio.</note>
+      </bibl></item>
+   <item xml:id="c2d1e749" n="2504">
+      <label>2504.</label>
+      <bibl><author>TACITO Cornelio</author>,<title> Gli annali dei fattj e guerre dei romani
+            tradotti da Giorgio Dati Fiorentino</title>, <pubPlace>Venezia</pubPlace> 1589.
+      </bibl></item>
+   <item xml:id="c2d1e816" n="2511">
+      <label>2511.</label>
+      <bibl><author>ANTIGUIDADES</author>
+         <title>arabes de Espana</title>, <pubPlace>Madrid</pubPlace>
+         <date>1780</date>. <note>Questo raro vol. comprende 31 tav. in foglio atlantico precedute
+            da un solo foglio di testo, il quale unicamente contiene l’elenco delle tavole medesime
+            mancanti di illustrazioni, che non furono mai pubblicate e rendesi conto in questo
+            foglio di quanto fu ordinato ed eseguito da tre professori dell’Accad. di S. Ferdinando
+            sotto il ministero del C. di Florída Bianca, acciò pel ritardo del testo non venissero
+            più lungamente defraudati i curiosi delle tavole, delle quali si pubblicarono pochi
+            esemplari.</note>
+      </bibl></item>
+   <item xml:id="c2d1e1062" n="2546" corresp="dcl:6zz">
+      <label>2546.</label>
+      <bibl><author>RICAULT</author>, <title>Histoire de l’état present de l’empire ottoman traduite
+            de l’anglais par M. Briot</title>, <pubPlace>Paris</pubPlace>
+         <date>1670</date>, in 12. Avec figures par Sebastien le Clerc. </bibl></item>
+   <item xml:id="c2d1e1068" n="2547" corresp="dcl:qjp">
+      <label>2547.</label>
+      <bibl><author>Del ROSSO Giuseppe</author>, <title>Ricerche sull’architettura egiziana</title>,
+            <pubPlace>Firenze</pubPlace>
+         <date>1787</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e1107" n="2552" corresp="dcl:8kd">
+      <label>2552.</label>
+      <bibl><author>ZOEGA Georgii</author>, <title>Nummi Egyptii. Vedi nella
+         Numismatica.</title></bibl></item>
+   <item xml:id="c2d1e1162" n="2559" corresp="dcl:w29">
+      <label>2559.</label>
+      <bibl><author>CARLI conte Giovan Rinaldo</author>, <title>Delle antichità italiche: seconda
+            edizione riveduta ed accresciuta dall’autore</title>, <pubPlace>Milano</pubPlace>
+         <date>1793 al 1795</date>, 4 vol., in 4, fig. <note>Opera delle più dotte e più profonde
+            che siano in questa materia, ricca di molte tavole ai luoghi voluti dal testo, o inserte
+            nelle stesse pagine intagliate in rame ed in legno. Vedi anche all’articolo Antichità
+            Romane.</note>
+      </bibl></item>
+   <item xml:id="c2d1e1244" n="2571" corresp="dcl:134">
+      <label>2571.</label>
+      <bibl><title>ESAME della controversia letteraria che passa tra il marchese Scipione Maffei e
+            il d. Anton Francesco Gori in proposito del Museo Etrusco</title>, in 8, M. 67.
+            <note>Sono esposti i pareri dell’uno e dell’altro in colonna ed è estratto dal Giornale
+            dei Letterati di Pisa.</note>
+      </bibl></item>
+   <item xml:id="c2d1e1361" n="2588">
+      <label>2588.</label>
+      <bibl><author>GORI Jacopo</author>, <title>Istoria della città di Chiusi in Toscana dal 1436
+            al 1595</title>, in fol., <pubPlace>Firenze</pubPlace>
+         <date>1747</date>. <note>Vedasi unita al Discorso sopra il nuovo ornato della guglia di S.
+            Pietro.</note>
+      </bibl></item>
+   <item xml:id="c2d1e1410" n="2595" corresp="dcl:f8c">
+      <label>2595.</label>
+      <bibl><author>LANZI Luigi</author>, <title>Saggio di lingua etrusca e di altre antiche <pb
+               type="cico" n="20"/> d’Italia, per servire alla storia de’ popoli, delle lingue e
+            delle arti</title>, <pubPlace>Roma</pubPlace>
+         <date>1789</date>, in 8, fig., vol. 3. <note>Con diverse tavole esattamente disegnate e in
+            fine all’ultimo volume una dissertazione sulla scultura degli antichi. Opera la più
+            classica che si conosca in materia di erudizione e di lingua etrusca.</note>
+      </bibl></item>
+   <item xml:id="c2d1e1418" n="2596">
+      <label>2596.</label>
+      <bibl><author>LEANTI Arcangelo</author>, <title>Lo stato presente della Sicilia accresciuto
+            colle notizie delle isole adjacenti</title>, vol. 2, <pubPlace>Palermo</pubPlace>
+         <date>1761</date>, in 8, fig. </bibl></item>
+   <item xml:id="c2d1e1500" n="2608">
+      <label>2608.</label>
+      <bibl><author>ORSINI Baldassare</author>, <title>Dissertazione sull’arco etrusco della via
+            Vecchia di Perugia, aggiuntavi una seconda dissertazione su di una porta etrusca in
+            Ispello nell’Umbria</title>, <pubPlace>Perugia</pubPlace>
+         <date>1807</date>, in 8, fig. </bibl></item>
+   <item xml:id="c2d1e1691" n="2637">
+      <label>2637.</label>
+      <bibl><author>VERMIGLIOLI</author>, <title>Del municipio Arnate nell’Umbria nuovamente
+            scoperto in marmo inedito nel Museo Lapidario di Perugia</title>,
+            <pubPlace>Perugia</pubPlace>
+         <date>1819</date>, in 8, M. 8. </bibl></item>
+   <item xml:id="c2d1e1697" n="2638">
+      <label>2638.</label>
+      <bibl><author>VERMIGLIOLI</author>, <title>Sepolcro etrusco chiusino illustrato nelle sue
+            epigrafi coll’aggiunta d’una memoria del sig. Giuseppe del Rosso nella parte
+            architettonica del monumento</title>, <pubPlace>Perugia</pubPlace>
+         <date>1819</date>, in 8, M. 80. <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+      </bibl></item>
+   <item xml:id="c2d1e1721" n="2641">
+      <label>2641.</label>
+      <bibl><author>VITALI Pier Antonio</author> (sebbene anonimo), <title>De Oppido Labici
+            dissertatio qua origo etiam atque compendiosa historia oppidi Montis Compiti in Latio
+            describitur</title>, <pubPlace>Romae</pubPlace>
+         <date>1778</date>, in 4, M. 1. <note>Quest’opuscolo fu scritto dal sig. avvocato Vitali
+            contro l’altre del Ficoroni stampato del 1745 intitolato Memorie della Città di
+            Labico.</note>
+      </bibl></item>
+   <item xml:id="c2d1e1838" n="2647" corresp="dcl:fg9">
+      <label>2647.</label>
+      <bibl><author>AZARI Antonio</author>, <title>Marmo taurobolico, locarnese, ossia dissertazione
+            su d’un basso rilievo esistente in Locarnio con testa di toro ec</title>.,
+            <pubPlace>Milano</pubPlace>
+         <date>1795</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e2109" n="2685" corresp="dcl:tnr">
+      <label>2685.</label>
+      <bibl><author>MORGHEN Filippo</author>, <title>Sei tavole che illustrano le antiche fabbriche
+            dei templi di Pesto dedicate al barone di Baltimore Pari d’Irlanda</title>,
+            <pubPlace>Napoli</pubPlace>
+         <date>1765</date>, in fol. <note>Precedute da un foglio di spiegazioni.</note>
+      </bibl></item>
+   <item xml:id="c2d1e2185" n="2696" corresp="dcl:zbv">
+      <label>2696.</label>
+      <bibl><author>PAUSANIAE</author>, <title>Veteris Greciae descriptio</title>,
+            <pubPlace>Torrentino</pubPlace>
+         <date>1551</date>, in fol. </bibl></item>
+   <item xml:id="c2d1e2515" n="2742">
+      <label>2742.</label>
+      <bibl><author>BANDURI Anselmi</author>, <title>Numismata Imperatorum romanorum a Trajano Decio
+            ad Paleologos Augustos</title>. Accessit Bibliotheca Nummaria, <pubPlace>Lutetiae
+            Parisiorum</pubPlace>
+         <date>1718</date>, in fol., fig., vol. 2. — <author>Taninii Hieronymi</author>,
+            <title>Numismata Imperatorum romanorum a Trajano Decio ad Costantinum Draconem ab
+            Anselmo Bandurio editore supplementum</title>, <pubPlace>Romae</pubPlace>
+         <date>1791</date>, in fol., fig. <note>Va unita cogli scrittori della Bizantina, ma può
+            stare anche separatamente. Questi tre volumi formano il complesso dell’opera che può
+            ritenersi fra le più copiose e principali di numismatica: le numerosissime tavole stanno
+            collocate fra il testo a’ luoghi rispettivi.</note>
+      </bibl></item>
+   <item xml:id="c2d1e2529" n="2744">
+      <label>2744.</label>
+      <bibl><author>BARTOLI Pietro Santi</author>, <title>Collezione di gemme intagliate la più
+            parte provenienti dal tesoro del duca Odescalchi</title>, in numero di 53 tavole in fol.
+         pic. <note>Questa rara collezione è mancante del testo, poiché avendo il duca fatto
+            intagliare in gran parte le gemme e i monumenti del suo ricchissimo museo, che aveva
+            intenzione di far continuare, rimase il tutto sospeso alla sua morte seguita nel 1713 e
+            immediatamente dopo quella, essendo cadute in mano d’un destro stampatore queste 53
+            tavole, ne furono furtivamente tirate alcune copie precedute da un bellissimo
+            frontespizio, ove il ritratto del duca in mezzo ai Geni delle virtù e delle scienze
+            vedesi collocato, disegnato da Car. Maratti ed inciso da Gustavo Ameling. Nel 1747 poi
+            comparve in intiero con queste e tutte le altre stampe riunite il Museo
+            Odescalchi.</note>
+      </bibl></item>
+   <item xml:id="c2d1e2965" n="2806">
+      <label>2806.</label>
+      <bibl><author>CHERON Elisabeth Sophie</author>, <title>Estampes</title>, vol., fol. <note>Sono
+            45 tavole componenti l’opera di questa disegnatrice, la più parte prese da antiche
+            gemme. In fronte a queste è il magnifico ritratto di lei intagliato avanti le lettere.
+            La maggior parte di queste tavole non sono state che disegnate da lei: quantunque ne
+            abbia anche alcune intagliate. Essa è conosciuta piuttosto sotto il suo nome di donzella
+            qui sopra indicato, che di Mad. Le Hay, come poi divenne pel matrimonio. Queste
+            incisioni di gemme sono di altrettanto bella esecuzione quanto infedele, piena di
+            arbitrio e priva affatto <pb type="cico" n="53"/> del gusto antico. Basti il vedere che
+            sono sostituiti fondi di paese, alterate figure, gruppi ec.</note>
+      </bibl></item>
+   <item xml:id="c2d1e3060" n="2820" corresp="dcl:qg2">
+      <label>2820.</label>
+      <bibl><author>DE DIONISIIS Jacobus</author>, <title>De monetis veronensibus praesertim sub
+            Ezelino conflatis, epistolae</title>, <pubPlace>Veronae</pubPlace>
+         <date>1779</date>, in fol., M. 17. </bibl></item>
+   <item xml:id="c2d1e3138" n="2831" corresp="dcl:pvj">
+      <label>2831.</label>
+      <bibl><author>EPIPHANII S.</author>
+         <title>De XII gemmis rationalibus summi sacerdotis: prodit nunc primo ex antiqua versione
+            latina</title>, opera et studio Francisci Foggini, <pubPlace>Romae</pubPlace>
+         <date>1743</date>, in 4. <note>Se è vero che questa sia l’opera di S. Epifanio, si può
+            riconoscere di quanto antica data sieno gli errori e i pregiudizj intorno la virtù
+            simpatica delle pietre, giacché di queste è specialmente trattato in quest’opera.</note>
+      </bibl></item>
+   <item xml:id="c2d1e3207" n="2841">
+      <label>2841.</label>
+      <bibl><author>FLOREZ Enrique</author>, <title>Medallas da las colonias de Espana hasta hoi no
+            pubblicadas, con las de los Reyes Godos; parte terciera</title>,
+            <pubPlace>Madrid</pubPlace>
+         <date>1773</date>. <note>Opera pregiatissima e rara specialmente in Italia. In principio è
+            il ritratto dell’autore intagliato da Carmona nel 1773. L’opera è ricca di 67 tav. in
+            rame fra i tre volumi. Le medaglie dei Goti poi sono intagliate in legno e inserite fra
+            il testo, ma ripetute e riunite in altre 8 tavole addizionali al fine. <pb type="cico"
+               n="58"/> p. 58</note>
+      </bibl></item>
+   <item xml:id="c2d1e3238" n="2846">
+      <label>2846.</label>
+      <bibl><author>FROELICH Erasmi</author>, <title>Appendicula ad nummo Augustorum et Caesarum ab
+            urbibus graece loquentibus cusos quos Vaillantius collegerat</title>,<pubPlace>
+            Viennae</pubPlace><date> 1734</date>, in 12, M. 74. <note>Con 19 tavole intagliate in
+            rame</note>. <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+      </bibl></item>
+   <item xml:id="c2d1e3250" n="2847">
+      <label>2847.</label>
+      <bibl><author>FROELICH Erasmi</author>, <title>Regum veterum numismata anecdota aut perrara
+            notis illustrata</title>,<pubPlace> Viennae</pubPlace>, in 4, fig., senz’anno. <note>Con
+            tre tavole intagliate in rame</note>. </bibl></item>
+   <item xml:id="c2d1e3322" n="2858">
+      <label>2858.</label>
+      <bibl><author>GIOVANNINI Giacomo</author>, <title>Disegni originali di medaglie, che servirono
+            agl’intagli per i libri del Serenissimo Duca di Parma</title>.<note> Vedi
+         Pedrusi</note>. </bibl></item>
+   <item xml:id="c2d1e3340" n="2860" corresp="dcl:8pb">
+      <label>2860.</label>
+      <bibl><author>GLANDORPIO Joan</author>, <title>Notitia familiae Caii Julii Cesaris dictatoris,
+            et Caii Caesaris Octaviani Augusti, intelligendae Romanae Historiae
+            perutilis</title>,<pubPlace> Parisiis</pubPlace><date> 1634</date>, in 4, M. 33.
+            <note>Opuscoletto prezioso per la sua erudizione</note>. </bibl></item>
+   <item xml:id="c2d1e3347" n="2861" corresp="dcl:w5b">
+      <label>2861.</label>
+      <bibl><author>GODOFREDI Jo. goettingensi</author>, <title>Deam monetam ex memoria veteri
+            auspiciis amplissimi philosophorum ordinis etc.</title>,
+            <pubPlace>Helmstadii</pubPlace><date> 1717</date>, in 4, M. 57. <note>Con quattro
+            medaglie su1 frontespizio</note>. </bibl></item>
+   <item xml:id="c2d1e3695" n="2911">
+      <label>2911.</label>
+      <bibl><author>MACCÀ Gaetano Girolamo</author>, <title>Della zecca vicentina trattato</title>,
+            <pubPlace> Vicenza</pubPlace>
+         <date>1802</date>, in 8, M. 68. <note>Non è che una moneta in legno sul
+            frontespizio.</note>
+      </bibl></item>
+   <item xml:id="c2d1e3812" n="2927" corresp="dcl:b8d">
+      <label>2927.</label>
+      <bibl><author>MENESTRIER Claude François</author>, <title>Lettre à M. Mayer sur une piece
+            antique qu’il a apporté de Rome</title>, in 4, M. 27. </bibl></item>
+   <item xml:id="c2d1e3830" n="2930" corresp="dcl:qvg">
+      <label>2930.</label>
+      <bibl><author>MILLIN Aubin Louis</author>, <title>Description d’un camée du cabinet <pb
+               type="cico" n="72"/> des antiques de la Bibliotheque Nationale</title>,
+            <pubPlace>Paris</pubPlace>
+         <date>an. VIII</date>, in 8, fig., M. 54. <note>L’intaglio in rame della tavola è lavoro
+            finissimo di Saint Aubin.</note>
+      </bibl></item>
+   <item xml:id="c2d1e4043" n="2960" corresp="dcl:gcg">
+      <label>2960.</label>
+      <bibl><author>PASSERII Joannis Baptistae</author>,<title> Novus thesaurus gemmarum veterum ex
+            insignioribus dactyliothecis selectarum <pb type="cico" n="77"/> cum
+            explicatione</title>, <pubPlace>Romae</pubPlace>
+         <date>1780 a 1797</date>, vol. 4, in fol., fig. <note>Vincenzo Brenna disegnò in dieci gran
+            tavole di arabeschi figurati (le quali sono in tutta l’opera ripetute) l’ornamento delle
+            pagine entro cui stanno intagliate le gemme incise da Giovan Maria Cassini. Ogni volume
+            ha cento tavole. Il Passeri estese le illustrazioni nei tre primi volumi, il Cassini
+            nell’ultimo. Nel secondo volume è aggiunta una dissertazione dell’Amaduzzi sopra una
+            gemma con un’appendice alle Memorie Glittografiche del Gori: nel terzo parimente una
+            dissertazione dello stesso in guisa d’epistola sopra d’un’altra gemma. Opera grandiosa
+            per speculazione, ma con poco merito intrinseco. Vedi anche <ref>Gori</ref>.</note>
+      </bibl></item>
+   <item xml:id="c2d1e4172" n="2979" corresp="dcl:18z">
+      <label>2979.</label>
+      <bibl><author>RAINSSANT</author>,<title> Discorso sopra dodici medaglie de’ giochi secolari di
+            Domiziano tradotta in italiano da N. N.</title>, <pubPlace>Brescia</pubPlace>
+         <date>1687</date>, in 8, M. 71. —<bibl>
+            <title>Lo stesso tradotto in latino dallo stesso autore</title>,
+               <pubPlace>Brescia</pubPlace>
+            <date>1687</date>, M. 71, in 8.</bibl>
+         <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+      </bibl></item>
+   <item xml:id="c2d1e4209" n="2984" corresp="dcl:b8k">
+      <label>2984.</label>
+      <bibl>
+         <title>RIFLESSIONI sopra una pietra flessibile pretesa ela <pb type="cico" n="81"/> stica,
+            che si conserva nel palazzo Borghese in Roma</title>, <pubPlace>Roma</pubPlace>
+         <date>1783</date>, in 4, M. 15. </bibl></item>
+   <item xml:id="c2d1e4230" n="2987">
+      <label>2987.</label>
+      <bibl><author>ROVILII Guglielmi</author>, <title>Promptuarium iconum insigniorum a saeculo
+            hominum etc.</title>, <pubPlace>Lugduni</pubPlace>
+         <date>1553</date>, in 4, fig. <note>Libro di bella e stimabile esecuzione per l’eleganza
+            della impressione e per le tavole in legno stampate fra il testo. Però l’antiquario vi
+            cerca l’esattezza e lo trova fatto a capriccio: sembra dal privilegio che nello stesso
+            anno quest’opera venisse pubblicata in francese, in spagnuolo, in italiano e in latino:
+            e in fatti abbiamo veduti esemplari italiani con la data dello stesso anno 1553. L’opera
+            è dedicata ad Enrico II e divisa in due parti.</note>
+      </bibl></item>
+   <item xml:id="c2d1e4254" n="2991" corresp="dcl:jc7">
+      <label>2991.</label>
+      <bibl><author>RUDIL de Berriae Huberti</author>, <title>Monumentorum galaticorum synopsis,
+            sive ad inscriptiones et numismata quae ad res galaticas spectant breves
+            conjecturae</title>, <pubPlace>Liburni</pubPlace>
+         <date>1772</date>, in 4, M. 8. <note>È singolare il modo con cui quest’autore rimanda i
+            suoi <pb type="cico" n="82"/> lettori ad una quantità di opere numismatiche citando il
+            numero e la pagina, per non far intagliare a sue spese quelle poche medaglie che
+            servivano ad illustrare i1 suo libro.</note>
+      </bibl></item>
+   <item xml:id="c2d1e4389" n="3010" corresp="dcl:qg2">
+      <label>3010.</label>
+      <bibl><author>SPERGESII Josephi, et VERCI Jo. Bapt. </author>, <title>Epistolae de monetis
+            veronensibus praesertim sub Ezzelino conflatis</title>, <pubPlace>Veronae</pubPlace>
+         <date>1779</date>, in 8, fig., M. 63. <note>Nel principio e nel fine sono due sole medaglie
+            intagliate in rame.</note>
+      </bibl></item>
+   <item xml:id="c2d1e4719" n="3056" corresp="dcl:hgb dcl:w2n">
+      <label>3056.</label>
+      <bibl><author>VICO</author>, <title>Le immagini con tutti i riversi trovati e le vite
+            degl’imperatori tratte dalle medaglie e dalle historie degli antichi</title>, libro
+         primo, <publisher>Eneas Vicus Parm.</publisher> fec., an. <date>1548</date>. <note>Altro
+            esemplare di prima freschezza e di mirabi1e intaglio, su cui di mano autografa è
+            riportata la versione in latino e molte correzioni della stessa opera che non fu poi
+            riprodotta; e dal millesimo egualmente emendato, vedesi che doveva pubblicarsi nel 1552
+            sostituendosi nel frontespizio all’arme del Zantani quella di S. Marco. Essendo levate
+            le carte di dedica, rimangono per conseguenza nel volume 55 foglietti. Il frontespizio e
+            la prima medaglia di ciascuno dei 12 Cesari sono egregiamente figurate; le altre
+            medaglie puramente intagliate senza ornamenti ed è illustrata la vita di ciascuno dei
+            Cesari con brevi dichiarazioni. Doveva aver per titolo questa versione, come leggesi in
+            cartellino: Divorum Caesarum verissimae imagines ex antiquis numismatibus desumptae
+            etc.</note>
+      </bibl></item>
+   <item xml:id="c2d1e4906" n="3083">
+      <label>3083.</label>
+      <bibl><title>La ZECCA in consulta di stato, sopra il saggio, conio e monete di tutte le città
+            d’Italia</title>. Opera divisa in due tomi data in luce da varj eruditi, T. 2,
+            <pubPlace>Milano</pubPlace>
+         <date>1772</date>, in 4. <note>Quest’opera preziosa è il prodotto delle memorie di varj <pb
+               type="cico" n="97"/> eruditi allora viventi, fra quali il Bellini, Domenico M. Manni,
+            il C. Bogino, Gio. Donato Turbolo, ove si trovano tutte le discussioni monetarie tra i
+            ministri e i fiscali de’ principali stati d’Italia, con tavole a’ luoghi indicati fra il
+            testo. Opera di grande utilità e profondità.</note>
+      </bibl></item>
+   <item xml:id="c2d1e4971" n="3091" corresp="dcl:609">
+      <label>3091.</label>
+      <bibl><author>AMADUTII Jo. Christoph.</author>, <title>Sylloge inscriptionum veterum
+            anecdotarum</title>, <pb type="cico" n="98"/>
+         <pubPlace>Romae</pubPlace>
+         <date>1776</date>, M. 61, in 8, accedit tabula honestae missionis Vespasiani Augusti cum
+         parte adversa. </bibl></item>
+   <item xml:id="c2d1e5024" n="3099" corresp="dcl:kc8">
+      <label>3099.</label>
+      <bibl><author>BARUFFALDI Girolamo</author>, <title>Osservazioni sopra un’antica iscrizione del
+            Vico Aventino oggidì Voghenza, villaggio nel territorio ferrarese</title>, trovata nelle
+         possessioni Cicognara, <pubPlace>Ferrara</pubPlace>
+         <date>1810</date>, in 4. </bibl></item>
+   <item xml:id="c2d1e5031" n="3100" corresp="dcl:rvd">
+      <label>3100.</label>
+      <bibl><author>BIANCHI D. Giovanni</author>, <title>Lettera sopra alcune antiche
+            iscrizioni</title>, <pubPlace>Rimino</pubPlace>
+         <date>1765</date>, in 12. </bibl></item>
+   <item xml:id="c2d1e5037" n="3101">
+      <label>3101.</label>
+      <bibl><author>BIANCHI D. Giovanni</author>, <title>Parere sopra il porto di Rimino</title>,
+            <date>1765</date>, in 12, M. 67. </bibl></item>
+   <item xml:id="c2d1e5125" n="3114">
+      <label>3114.</label>
+      <bibl><author>GARUFFIO Josepho</author>, <title>Lucerna lapidaria quae monumenta, epitaphia,
+            inscriptiones, et sepulchra tum gentilium tum christianorum via Flaminia et Arimini
+            scrutatur accensa</title>, <pubPlace>Arimini</pubPlace>
+         <date>1691</date>, in 8, M. 49 e 35. </bibl></item>
+   <item xml:id="c2d1e5170" n="3120" corresp="dcl:009">
+      <label>3120.</label>
+      <bibl>
+         <title>INSCRIPTIONES antiquae basilicae Sancti Pauli ad viam Ostiensem</title>,
+            <pubPlace>Romae</pubPlace>
+         <date>1654</date>, in fol., Christianorum inscriptiones 487, Ethnicorum 174, Graecae 56,
+         con indici ec. M. 82. </bibl></item>
+   <item xml:id="c2d1e5221" n="3128">
+      <label>3128.</label>
+      <bibl><author>MARMORA</author>, <title>vedi Arundelianorum, Zacharias, Zabarella, Vairani, del
+            Signore, Rivaultella, Paulovich, Olivieri, Malvasia, Caryophili, Maffei etc.</title>
+      </bibl></item>
+   <item xml:id="c2d1e5234" n="3130">
+      <label>3130.</label>
+      <bibl>Manca per error del copista.</bibl></item>
+   <item xml:id="c2d1e5266" n="3134">
+      <label>3134.</label>
+      <bibl><author>MITTAIRE Michael</author>, <title>Marmorum Arundelianorum, Seldelianorum
+            aliorumque Academicae Oxoniensi donatorum cum commentariis etc.</title> secunda editio,
+            <pubPlace>Londini</pubPlace>
+         <date>1732</date>, in fol., fig. <note>Edizione di cui non furono tirati che 300 esemplari.
+            Vedi Seldeni e Arundelianorum.</note>
+      </bibl></item>
+   <item xml:id="c2d1e5605" n="3183">
+      <label>3183.</label>
+      <bibl><author>BONARDO Vincenzo</author>, <title>Discorso intorno all’origine, antichità ec.
+            della Benedizione Pontificale degli Agnusdei</title>, <pubPlace>Roma</pubPlace>
+         <date>1621</date>, in 8, M 75. </bibl></item>
+   <item xml:id="c2d1e5620" n="3185" corresp="dcl:4w7">
+      <label>3185.</label>
+      <bibl><author>BONI</author>, <title>Sulla pittura di un gonfalone della Confraternita di S.
+            Maria di Castello e su di altre opere fatte nel Friuli da Giovanni da Udine,
+            lettera</title>, <pubPlace>Udine</pubPlace>
+         <date>1707</date>, in 8, M. 53. </bibl></item>
+   <item xml:id="c2d1e5638" n="3188">
+      <label>3188.</label>
+      <bibl><author>BRISSON</author>, <title>Trois discours etc. Vedilo all’articolo Poullet con cui
+            è legato</title>. <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+      </bibl></item>
+   <item xml:id="c2d1e5657" n="3190" corresp="dcl:gs0">
+      <label>3190.</label>
+      <bibl><author>CAPYCII Cajetani Mariae</author>, <title>Opuscula antiquaria in unum
+            collecta</title>, <pubPlace>Neapoli</pubPlace>
+         <date>1785</date>, in 4, fig., M. 9. <note>Sono la più parte con le rispettive tavole a’
+            luoghi indicati nel testo.</note>
+      </bibl></item>
+   <item xml:id="c2d1e5708" n="3198">
+      <label>3198.</label>
+      <bibl><title>CHRONICON universale per viam epithomatis</title>,
+            <pubPlace>Norimbergae</pubPlace>
+         <date>1493</date>, in fol., fig. <note>Veramente quantunque dai bibliografi s’intitoli così
+            questo libro, può riportarsi qui il suo vero frontespizio, che è il seguente: Registrum
+            hujus operis libri chronicarum cum figuris et imaginibus ab initio mundi. Dopo questo
+            frontespizio, seguono 19 fogli, che contengono Tabula operis hujus de temporibus mundi.
+            Comincia poi il testo dal foglio segnato 1 al 299, dietro cui adest nunc, studiose
+            lector, finis libri chronicarum per viam epithomatis et breviarj compilati etc. ad
+            intuitum autem et preces providorum civium Sebaldi Schreyer et Sebastiani Kamermaister
+            hunc librum dominus Antonius Koberger Nurimbergae impressit. Adhibitis tamen viris
+            mathematicis plugendique artis peritissimi Michaele Wolgemut, et Wilhelmo Pleidenwurft;
+            quarum solerti accuratissimaque animadversione tum civitatum, tum illustrium virorum
+            figurae insertae sunt. Consumatum autem duodecima mensis Julii anno salutis nostrae
+            1493. Libro che ha pregio a cagione dello immenso numero di tavole di quei primi
+            intagliatori in legno, ma che non è di alcuna rarità, a cagione dei molti esemplari che
+            se ne incontrano. È da notarsi però che alla pagina 266 pare che finisca il <pb
+               type="cico" n="111"/> volume, completo in famosissima Nirimbergensis urbe ecc. (come
+            vi si legge). Poi nel nostro esemplare sono legati i 5 fol., non numerati, che
+            dovrebbero trovarsi alla fine de Sarmacia regione <fw type="foot"/>
+            <pb type="memofonte"/>
+            <fw type="head"/> Europae, indi ripiglia una continuazione della sesta età del mondo col
+            foglio 267 e prosegue sino al fine, come abbiamo più sopra indicato.</note>
+      </bibl></item>
+   <item xml:id="c2d1e5810" n="3213" corresp="dcl:r86">
+      <label>3213.</label>
+      <bibl>
+         <title>DIFESA per la serie de’ Profeti di Roma del p. Corsini contro la censura fattale
+            nelle osservazioni sul Giornale Pisano</title>, <pubPlace>Bologna</pubPlace>
+         <date>1772</date>, in 4, M. 27. <note>Si riportano tutte le accuse contro il Corcini, le
+            quali vengono smentite, o difese in 142 pagine.</note>
+      </bibl></item>
+   <item xml:id="c2d1e5855" n="3219" corresp="dcl:9w0">
+      <label>3219.</label>
+      <bibl><author>FABRONI Giovanni</author>,<title> Due memorie lette nella società degli amatori
+            della Storia Patria Fiorentina su la derivazione e coltura degli antichi popoli d’Italia
+            e sulle epoche della storia fiorentina fino al 1292</title>,
+            <pubPlace>Firenze</pubPlace>, in 8, <date>1803</date>. </bibl></item>
+   <item xml:id="c2d1e5913" n="3227" corresp="dcl:cp7">
+      <label>3227.</label>
+      <bibl><author>GCHROTERI Ernesti Frid.</author>, <title>De Lamiis, dissertatio
+         juridica</title>, <pubPlace>Jenae</pubPlace>
+         <date>1670</date>, in 4, M. 64. <note>La singolarità di alcuni opuscoli e il bizzarro
+            genere di erudizione che contengono ci ha spesso determinato ad accoglierli in questa
+            collezione, sebbene per il loro titolo non sembri a prima vista che possano
+            appartenervi.</note>
+      </bibl></item>
+   <item xml:id="c2d1e5931" n="3230">
+      <label>3230.</label>
+      <bibl><author>GIAMBULLARI Pier Francesco</author>, <title>Del sito forma e misura dell’Inferno
+            di Dante</title>, <pubPlace>Firenze</pubPlace>, per <publisher>Neri
+            Dortellata</publisher>, <date>1544</date>, in 8. <note>In principio e in fine è l’arca
+            di Noè col motto di Dante e <pb type="cico" n="115"/> l’ortografia per la pronuncia è
+            esposta in questo curioso libretto egualmente a quella del Convito di Platone. Ved.
+            Ficino Marsilio.</note>
+      </bibl></item>
+   <item xml:id="c2d1e5939" n="3231">
+      <label>3231.</label>
+      <bibl><author>GOURNAY</author>, <title>Egalité des hommes et des femmes</title>. <note>Vedilo
+            all’articolo Poullet fra le Costumanze antiche e moderne con cui è legato</note>.
+      </bibl></item>
+   <item xml:id="c2d1e5976" n="3237">
+      <label>3237.</label>
+      <bibl><author>GUAZZESI Lorenzo</author>, <title>Dissertazioni V</title>,<pubPlace>
+            Pisa</pubPlace><date> 1761</date>, in 4, <note>sugli anfiteatri della Toscana, intorno
+            alcuni fatti d’Annibale, intorno la guerra Gallica Cisalpina l’anno di Roma 529, intorno
+            la disfatta e morte di Totila, intorno alla via Cassia da Chiusi a Firenze, M.
+         32</note>. </bibl></item>
+   <item xml:id="c2d1e6028" n="3244">
+      <label>3244.</label>
+      <bibl><author>JACUTII Matthaei</author>, <title>Historia visionis Constantini Magni</title>,
+            <pubPlace>Romae</pubPlace><date> 1755</date>, in 4. </bibl></item>
+   <item xml:id="c2d1e6034" n="3245">
+      <label>3245.</label>
+      <bibl><author>JACUTII Matthaei</author>, <title>Commentarium in titulum Bonusae et
+            Mennae</title>, <pubPlace>Romae</pubPlace><date> 1758</date>, in 4, M. 3. </bibl></item>
+   <item xml:id="c2d1e6130" n="3259">
+      <label>3259.</label>
+      <bibl><author>MAFFEI march. Scipione</author>,<title> Rime e prose parte raccolte da varj
+            libri e parte non più stampate</title>, <pubPlace>Venezia</pubPlace><date> 1719</date>,
+         in 4. <note>Nelle prose sono trattati alcuni argomenti relativi a oggetti d’arte e
+            d’antiquaria</note>. </bibl></item>
+   <item xml:id="c2d1e6155" n="3263">
+      <label>3263.</label>
+      <bibl><author>MARGARITA</author><title> philosophica nova cui insunt sequentia epigrammata in
+            commendationem operis</title>,<pubPlace> Argentinae</pubPlace><date> 1512</date>, in 4.
+            <note>In fine Joannes Gruningerus operis excusor etc. Con molte figure in legno. Autore
+            della quale è Giorgio Reischio ed è una ristampa della prima edizione stampata a
+            Friburgo nel 1503. Queste erano le antiche enciclopedie e in questa, che reputasi fra le
+            migliori, sono infatti infinite buone notizie. Va unita in questo esemplare l’appendice
+            Matheseos in Margarita Philosophica stampato nello stesso luogo e dal medesimo
+            stampatore nel 1515; e nelle figure della prospettiva vedesi copiato il trattato del
+            Viator, in parte, senza nominarlo. In fine è legata</note>. </bibl></item>
+   <item xml:id="c2d1e6161" n="3264">
+      <label>3264.</label>
+      <bibl><author>MARGARITA philosophica Arithmetica Boetii</author>, <note>Con questo solo titolo
+            nel frontespizio esterno. Poi volgendo la pagina Incipiunt duo libri de arithmetica
+            Anitii Manilii Severi Boethii ec. In fine impressa per Erhardum Ratdolt viri
+            solertissimi eximia industria et mira imprimendi <pb type="cico" n="119"/> arte, qua
+            nuper Venetiis, nunc Augustae excellit anno 1488, in 4 gotico, non di 47 foglietti, come
+            dice il Panzer, ma 448 poiché il frontespizio esterno con le due parole sovra indicate è
+            aderente al foglietto secondo. Prima edizione piuttosto rara. Vedi anche Reich.</note>
+      </bibl></item>
+   <item xml:id="c2d1e6181" n="3267" corresp="dcl:2cx">
+      <label>3267.</label>
+      <bibl><author>MARQUEZ D. Pietro Giuseppe</author>, <title>Traduzione dallo spagnuolo di un
+            saggio dell’Astronomia cronologica e mitologica degli antichi messicani di D. Antonio
+            Leone e Gama</title>, <pubPlace>Roma</pubPlace>
+         <date>1804</date>, in 8, fig. </bibl></item>
+   <item xml:id="c2d1e6206" n="3271">
+      <label>3271.</label>
+      <bibl><author>MAZZUCCHELLI Pietro</author>, <title>La Bolla di Maria moglie di Onorio
+            imperatore che si conserva nel Museo Trivulzio <fw type="foot"/>
+            <pb type="memofonte"/>
+            <fw type="head"/> brevemente spiegata</title>, <pubPlace>Milano</pubPlace>
+         <date>1819</date>, in 4 grande. <note>Esemplare in carta velina distinta in mezzo
+            tinto.</note>
+      </bibl></item>
+   <item xml:id="c2d1e6257" n="3278" corresp="dcl:n86">
+      <label>3278.</label>
+      <bibl><author>MOLISI di Nola Giovan Battista</author>, <title>Cronica della antichissima e
+            nobilissima città di Crotone e della Magna Grecia</title>, <pubPlace>Napoli</pubPlace>
+         <date>1649</date>, in 4 pic. </bibl></item>
+   <item xml:id="c2d1e6263" n="3279">
+      <label>3279.</label>
+      <bibl>
+         <title>MUESTRA de letras quelle varà la impresion que se hace por la Real Biblioteca de la
+            collecion canonica espannola por el Codice Gotico Vigilano del siglo X con algunas
+            laminas de esto celebre original imitado con propriedad el tosco debuxo de a quel
+            tiempo</title>, f., M. 84. </bibl></item>
+   <item xml:id="c2d1e6276" n="3281">
+      <label>3281.</label>
+      <bibl><author>MURATORI Lodovico Antonio</author>, <title>Sposizione dell’insigne tavola di
+            bronzo spettante a fanciulle e fanciulli alimentarii di Trajano Augusto in Italia,
+            dissotterrata nel territorio di Piacenza nel 1747</title>, <pubPlace>Firenze</pubPlace>
+         <date>1748</date>, in 8, fig. </bibl></item>
+   <item xml:id="c2d1e6333" n="3289">
+      <label>3289.</label>
+      <bibl><author>OLIVIERI</author>, <title>Dissertazione sopra due antiche tavolette
+            d’avorio</title>, <pubPlace>Pesaro</pubPlace>
+         <date>1743</date>, in 8, M. 35. </bibl></item>
+   <item xml:id="c2d1e6370" n="3295" corresp="dcl:f2p">
+      <label>3295.</label>
+      <bibl><author>Ovenabii Joannes Christianus</author>,<title> Dissertatio historica
+            architectonica de Artemisia et Mausolo</title>, <pubPlace>Lipsiae</pubPlace>
+         <date>1714</date>, in 8, fig., M. 57. </bibl></item>
+   <item xml:id="c2d1e6403" n="3300" corresp="dcl:dcq">
+      <label>3300.</label>
+      <bibl><author>PASSERII Joannis Baptistae</author>, <title>De marmoreo sepulcrali cinerario
+            Perusiae effosso arcanis ethnicorum sculpturis insignito</title>,
+            <pubPlace>Romae</pubPlace>
+         <date>1773</date>, in 4, fig., M. 1 e 78. <note>Oltre la tavola del monumento sono parecchi
+            altri intagli di gemme in diversi luoghi fra il testo.</note>
+      </bibl></item>
+   <item xml:id="c2d1e6409" n="3301" corresp="dcl:bch">
+      <label>3301.</label>
+      <bibl><author>PASSERII Joannis Baptistae</author>, <title>Spiegazione delle sculture d’un
+            antico marmoreo sarcofago nel monastero degli Olivetani in Pesaro giusta il sentimento
+            dell’ab. Giovan Battista Passeri</title>, <pubPlace>Perugia</pubPlace>
+         <date>1773</date>, in 4, fig., M. 28. <note>Con una tavola grande intagliata in
+            rame.</note>
+      </bibl></item>
+   <item xml:id="c2d1e6454" n="3307">
+      <label>3307.</label>
+      <bibl><author>Du PEYRAT G.</author>, <title>Le tableau de la calomnie depeinte au vive par
+            Apelle, interprété</title>, <pubPlace>Paris</pubPlace>
+         <date>1604</date>, in 12. <note>Il libretto singolare è intitolato con lunga e curiosa
+            dedicatoria a très-haute et très-puissante Princesse Diane legitimée de France, duchesse
+            d’Angouléme.</note>
+      </bibl></item>
+   <item xml:id="c2d1e6499" n="3314">
+      <label>3314.</label>
+      <bibl><author>PROCOPIO Cesariense</author>, <title>Delle guerre di Giustiniano contro i
+            persiani e contro i vandali, volgarizzate da Benedetto Egio da Spoleti</title>,
+            <pubPlace>Venezia</pubPlace>, <date>1547</date>, in 8, per <publisher>Michel
+            Tramezzino</publisher>. — Aggiuntovi: <title>Il libro degli edifizii di Giustiniano
+            imperatore</title>, <pubPlace>Venezia</pubPlace>
+         <date>1547</date>, in 8. <note>Sono amendue i libri con dediche separate intitolati al
+            molto magnifico M. Gio. Soranzo e stampati con eleganza di tipi.</note>
+      </bibl></item>
+   <item xml:id="c2d1e6530" n="3318" corresp="dcl:8pd dcl:867">
+      <label>3318.</label>
+      <bibl><author>RANGIASCHI Sebastiano</author>, <title>Del tempietto di Marte Ciprio e de’ suoi
+            monumenti dissotterrati nella campagna di Gubbio l’anno 1781. Al sig. Anni <pb
+               type="cico" n="125"/> bale degli Abati Olivieri</title>, <pubPlace>Perugia</pubPlace>
+         <date>1784</date>, in 12, figurato. <note>Avvi un’aggiunta ed emenda intitolata all’ab.
+            Lanzi e 5 tav. intagliate in rame.</note>
+      </bibl></item>
+   <item xml:id="c2d1e6538" n="3319" corresp="dcl:p88">
+      <label>3319.</label>
+      <bibl><author>RAPONI Ignatii</author>, <title>De quodam epigrammate graeco. Romae in hortis
+            Coelimontanis extante</title>, <pubPlace>Velitris</pubPlace>
+         <date>1788</date>, in 4, M. 23. </bibl></item>
+   <item xml:id="c2d1e6544" n="3320" corresp="dcl:vrm">
+      <label>3320.</label>
+      <bibl>
+         <title>RAPPORTO della commissione di commercio al gran consiglio sopra il nuovo campione di
+            misura lineare con annotazioni del cittadino Venturi rappresentante del popolo</title>,
+            <pubPlace>Milano</pubPlace>, dalla <publisher>Tipografia Nazionale</publisher>,
+            <date>anno VI</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e6563" n="3323">
+      <label>3323.</label>
+      <bibl>
+         <title>SAGGIO di dissertazioni dell’Accademia Palermitana del buon gusto, vol. I</title>,
+            <pubPlace>Palermo</pubPlace>
+         <date>1755</date>, in 4, M. 32. <note>Contiene questo volume 8 dissertazioni in materia
+            d’antichità colle rispettive tavole degli oggetti al principio di ciascuna.</note>
+      </bibl></item>
+   <item xml:id="c2d1e6589" n="3327" corresp="dcl:5wd">
+      <label>3327.</label>
+      <bibl><author>SANTI Bartoli Pietro</author>, <title>Raccolta di varie antichità e lucerne
+            antiche intagliate</title>, <pubPlace>Roma</pubPlace>, in 4. <note>Questa non è che una
+            raccolta di 31 tavole, prodotta in altre diverse opere, riunite sotto questo
+            frontespizio per speculazione libraria.</note>
+      </bibl></item>
+   <item xml:id="c2d1e6596" n="3328">
+      <label>3328.</label>
+      <bibl><author>SARTORIUS George</author>, <title>Essai sur l’état civil, et politique des
+            peuples d’Italie sous le governement des Goths</title>, <pubPlace>Paris</pubPlace>
+         <date>1811</date>, in 8. <note>Ottime ricerche anche per la cognizione dei monumenti nei
+            bassi tempi.</note>
+      </bibl></item>
+   <item xml:id="c2d1e6608" n="3330">
+      <label>3330.</label>
+      <bibl><author>SAVARON</author>, <title>Traité que les lettres sont l’ornement des rois. Vedilo
+            all’articolo Poullet con cui è legato</title>. </bibl></item>
+   <item xml:id="c2d1e6659" n="3337" corresp="dcl:gch">
+      <label>3337.</label>
+      <bibl><author>SCHWARTIO Christ. Gottl.</author>, <title>De sacrorum detestatione ex antiquo
+            romanorumque jure liber singularis</title>, <pubPlace>Lipsiae</pubPlace>, editio 2,
+            <date>1753</date>, in 4, M. 41. <note>Col frontespizio figurato.</note>
+      </bibl></item>
+   <item xml:id="c2d1e6690" n="3342" corresp="dcl:krs dcl:ckm">
+      <label>3342.</label>
+      <bibl><author>Siebenkees Jo. Philippi</author>, <title>Expositio tabulae hospitalis ex aere
+            antiquissimae in Museo Borgiano Velitris adservatae</title>, <pubPlace>Romae</pubPlace>
+         <date>1789</date>, in 4, fig., M. 18 e 78. <pb type="cico" n="128"/>
+      </bibl></item>
+   <item xml:id="c2d1e6698" n="3343" corresp="dcl:qzh">
+      <label>3343.</label>
+      <bibl><author>De SIMEONIBUS Thoma</author>, <title>Historica dissertatio de tollenda
+            ambiguitate inter duas antiquas romanas matronas Aniciam Faltoniam Probam, et Valeriam
+            Faltoniam Probam</title>, <pubPlace>Bononiae</pubPlace>
+         <date>1692</date>, in 4, M. 40. <note>La prima fu moglie di Sesto Petronio Probo e la
+            seconda di Adelfo Proconsole e fu poetessa d’ingegno meccanico che trasse dalle opere di
+            Virgilio un miserabile centone della vita di Cristo storpiando quel classico senza pietà
+            e trovando un editore della sua puerile fatica nel 1692.</note>
+      </bibl></item>
+   <item xml:id="c2d1e6729" n="3347" corresp="dcl:szk">
+      <label>3347.</label>
+      <bibl><author>STIGLIZII Jo. Conradi</author>, <title>De Menide sacro antiquorum codicum
+            ornamento commentarius criticus, cui accessit de lunulatis veterum gentilium insignibus
+            etc.</title>, <pubPlace>Erfordiae</pubPlace>
+         <date>1747</date>, in 4, M. 2. <note>Questo opuscolo stampato in grande e magnifica carta è
+            dedicato al Gori ed avvi aggiunto il suo ritratto che non trovasi negli altri esemplari,
+            per esser questo di dedica.</note>
+      </bibl></item>
+   <item xml:id="c2d1e6735" n="3348" corresp="dcl:82w">
+      <label>3348.</label>
+      <bibl><author>SUMMACHIO Zacynthio</author>, <title>Cion Paphlagonicus sive columna in gloriam
+            D. Alipii Cionitae eiecta</title>, <pubPlace>Venetiis</pubPlace>
+         <date>1667</date>, in 8, M. 45. <note>Con una tavola in principio.</note>
+      </bibl></item>
+   <item xml:id="c2d1e6741" n="3349">
+      <label>3349.</label>
+      <bibl>
+         <title>SYMBOLAE literariae opuscula varia philologica scientifica antiquaria, signa,
+            lapides, numismata, gemmas, et monumenta medii aevi nunc primum edita complectentes,
+            vol. 2</title>, in fol., <date>1748</date>. <note>In questi primi due volumi stanno le
+            dissertazioni del Gori, del Passeri relative alle antichità ercolanensi. Il terzo volume
+            trovasi legalo colle miscellanee nel tomo 95.</note>
+      </bibl></item>
+   <item xml:id="c2d1e6747" n="3350" corresp="dcl:xvj">
+      <label>3350.</label>
+      <bibl><author>TANURSI Fran. M. patricii Ripani</author>, <title>Historiae patriae epitome et
+            Joa. Garzonii ac Theodosii Quatrini de rebus Ripanis nunc primum edita.</title> Omnia
+         recensuit <pb type="cico" n="129"/> atque emendavit Cajetanus Fr. M. Tanursi filius,
+            <pubPlace>Romae</pubPlace>
+         <date>1787</date>, in 8, M. 58. </bibl></item>
+   <item xml:id="c2d1e6755" n="3351" corresp="dcl:cs7">
+      <label>3351.</label>
+      <bibl><author>TASSONI Alexandri Mariae</author>, <title>Dissertatio de collegiis</title>,
+            <pubPlace>Romae</pubPlace>
+         <date>1792</date>, in 4, M. 21. <note>S’aggira questa sui diritti del principato nella
+            legittima instituzione d’ogni corporazione.</note>
+      </bibl></item>
+   <item xml:id="c2d1e6762" n="3352" corresp="dcl:0ks dcl:cgf">
+      <label>3352.</label>
+      <bibl>
+         <title>TITI Flavii Clementis viri consularis et martiris tumulus illustratus</title>,
+            <pubPlace>Urbini</pubPlace>
+         <date>1727</date>, in 4, M. 3. <note>Esemplare in carta grande.</note>
+      </bibl></item>
+   <item xml:id="c2d1e6780" n="3355" corresp="dcl:bgs">
+      <label>3355.</label>
+      <bibl><author>VAUCANSON M.</author>, <title>Le mécanisme du fluteur automate, avec la
+            description d’un canard artificiel, mangeant, beuvant, digerant, et se vuidant etc.
+            inventé par le même</title>, <pubPlace>Paris</pubPlace>
+         <date>1738</date>, in 4, M. 64. <note>Opuscolo singolare con una tavola intagliata in rame.
+            Questa macchina fu presentata all’Accademia delle Scienze in Parigi.</note>
+      </bibl></item>
+   <item xml:id="c2d1e6786" n="3356" corresp="dcl:dk7">
+      <label>3356.</label>
+      <bibl><author>VENNI Giuseppe</author>, <title>Elogio storico delle gesta del B. Odorico
+            dell’ordine de’ min. conventuali colla storia da lui dettata de’suoi Viaggi Asiatici
+            presentata agli amatori delle antichità e illustrata</title>,
+            <pubPlace>Venezia</pubPlace>, <publisher>Zatta</publisher>, <date>1761</date>, in fol.,
+         fig. <note>In principio è una gran tavola intagliata da un quadro di Domenico Scaramuccia,
+            che rappresenta questo viaggiatore battezzando alcune persone e alla p. 36 altra gran
+            tavola con sarcofago e antichità.</note>
+      </bibl></item>
+   <item xml:id="c2d1e6995" n="3383">
+      <label>3383.</label>
+      <bibl><author>DORIGNY Nicolas</author>, <title>Oeuvre contenante divers sujets sacrés, et
+            profans, d’après Raphael, Guerchin, Dominiquin, Lanfranc, le Guide, Cigoli, et
+            Albano</title>. In tutto 20 grandi tavole in rame. <pubPlace>Parigi</pubPlace>
+         <date>1770</date>, in fol. atlant. </bibl></item>
+   <item xml:id="c2d1e7181" n="3409">
+      <label>3409.</label>
+      <bibl><author>MAZZOLA Francesco detto il Parmigianino</author>, <title>Raccolta di disegni
+            originali, tolti dal gabinetto Sanvitali</title>, incisi da Benigno Bossi,
+            <pubPlace>Roma</pubPlace>
+         <date>1772</date>, in fol. — <note>Aggiuntavi una raccolta di teste, inventate, di <pb
+               type="cico" n="139"/> segnate e incise da Benigno Bossi; e un ultimo quinternetto di
+            12 teste intitolato: Fisonomie possibili, 1676, in fol. Le acque forti di questo
+            incisore sono piene di grazia e di brio ec.</note>
+      </bibl></item>
+   <item xml:id="c2d1e7327" n="3425">
+      <label>3425.</label>
+      <bibl>
+         <title>NOTIZIA della più copiosa Galleria di Schleisheim presso Monaco</title>,
+            <date>1810</date>, in 8, fig. </bibl></item>
+   <item xml:id="c2d1e7339" n="3427">
+      <label>3427.</label>
+      <bibl><author>OESTERREICHER Mathias</author>, <title>La stessa aumentata</title>,
+            <date>1774</date>, in 8, seconda edizione. </bibl></item>
+   <item xml:id="c2d1e7366" n="3431" corresp="dcl:fcg">
+      <label>3431.</label>
+      <bibl><author>PATCH</author>, <title>Collezione delle teste di Masaccio</title>. Vedi Masaccio
+         tra le vite degli artisti. </bibl></item>
+   <item xml:id="c2d1e7423" n="3439" corresp="dcl:x21">
+      <label>3439.</label>
+      <bibl>
+         <title>PITTURE di Antonio Allegri detto il Correggio. Descrizione d’una pittura di Antonio
+            Allegri detto il Correggio</title>, in 16. <note>Lo stampatore Bodoni pubblicò questo
+            libretto in quel momento che distendevasi la grand’opera.</note>
+      </bibl></item>
+   <item xml:id="c2d1e7429" n="3440">
+      <label>3440.</label>
+      <bibl>
+         <title>Le PITTURE della Cappella di Niccolò V. Opere del B. Giovanni Angelico da Fiesole
+            esistenti in Vaticano disegnate e incise a contorni da Fran. Gio. <pb type="cico"
+               n="145"/> Giacomo Romano</title> in 16 rami, <pubPlace>Roma</pubPlace>
+         <date>1811</date>, in fol. mass., M. 107. <note>Esemplare di prima impressione; opera
+            eseguita con esattezza.</note>
+      </bibl></item>
+   <item xml:id="c2d1e7470" n="3445">
+      <label>3445.</label>
+      <bibl>
+         <title>RACCOLTA di opere scelte di pittori della scuola veneziana</title>, disegnate ed
+         incise da le Febre, da Silvestro Manaigo e da Andrea Zucchi, veneziani, pubblicate per la
+         prima volta ed unite al numero di 90 da <publisher>Teodoro Viero</publisher>,
+            <pubPlace>Venezia</pubPlace>
+         <date>1786</date>, in fol. atlant. — A cui serve di seconda parte l’aggiunta Raccolta di
+         opere scelte, dipinte da’ più celebri maestri italiani, fiamminghi e francesi, in numero di
+         112 stampe, tratte da quadri esistenti in Venezia, incise da Pietro Monaco nel 1740, ora
+         pubblicate da Teodoro Viero, Venezia 1789, in gran fol. atl. </bibl></item>
+   <item xml:id="c2d1e7515" n="3452">
+      <label>3452.</label>
+      <bibl><author>Sanzio Rafaello d’Urbino</author>. Vedi Sommerau. Vedi Imagines Novi Testamenti
+         (fra le Biblie figurate). Vedi Scoperta e Piroli.</bibl></item>
+   <item xml:id="c2d1e7534" n="3454">
+      <label>3454.</label>
+      <bibl><title>SCHOLA Italica. Aggiuntovi: Disegni originali d’eccellenti pittori esistenti
+            nella Galleria di Firenze, imitati ed <pb type="cico" n="148"/> incisi da Stefano
+            Molinari</title>, <pubPlace>Firenze</pubPlace>
+         <date>1774</date>, tav. 50.</bibl>
+      <note>Le quaranta tavole della Scuola Italiana sono intagliate dai migliori artisti italiani,
+         come Cunego, Volpato, Cappellan, Perini ed altri simili. Opera ben eseguita e ben scelta.
+         Esemplare di prima freschezza. La collezione poi del Molinari, che in 60 tavole comprende
+         174 disegni, è forse la più bella e preziosa che si conosca a quel modo eseguita e deve
+         ritenersi come il più bel saggio che aver si possa in quel genere.</note>
+   </item>
+   <item xml:id="c2d1e7611" n="3465" corresp="dcl:g8p">
+      <label>3465.</label>
+      <bibl><author>TOWNLEY</author>. Vedi Monumens antiques inedits.</bibl></item>
+   <item xml:id="c2d1e7656" n="3471" corresp="dcl:z2f">
+      <label>3471.</label>
+      <bibl><author>ZANETTI Anton Maria</author>, <title>Altro esemplare miniato, preceduto da una
+            carta immediatamente dopo il frontespizio, intitolata: Memoria intorno la vita e le
+            opere di Anton M. Zanetti, dalla quale rilevasi che quest’opera fu imaginata, disegnata,
+            illustrata ed anche alcun esemplare miniato dallo stesso Anton Maria Zanetti</title>.
+         Girolamo suo minor fratello fu l’estensore di questa memoria. </bibl></item>
+   <item xml:id="c2d1e7744" n="3482">
+      <label>3482.</label>
+      <bibl><author>Becker Guillaume Gottlieb</author>, <title>Augusteum ou description des monumens
+            antiques qui se trouvent à Dresde</title>, <pubPlace>Leipzig</pubPlace>
+         <date>1804</date>, vol. 3, in fol., fig. <note>Opera eseguita con precisione e con ricca
+            eleganza. Vedi Recueil.</note>
+         <pb type="cico" n="154"/>
+      </bibl></item>
+   <item xml:id="c2d1e7771" n="3486" corresp="dcl:5kh">
+      <label>3486.</label>
+      <bibl><author>BOUCHARDON Edmundo</author>, <title>Statua antiquae</title>. Vedi Preisler.
+      </bibl></item>
+   <item xml:id="c2d1e7861" n="3499">
+      <label>3499.</label>
+      <bibl>
+         <title>DESCRIPTION de la statue equestre que la Compagnie des Indes Orientales de Danemarc
+            a consacré à la gloire de Frederic V</title>, <pubPlace>Copenhague</pubPlace>
+         <date>1774</date>, in fol., fig. <note>In tedesco, danese e francese. Nelle 9 tavole e nel
+            testo si rende conto delle macchine che M. Saly ha adoperate in quest’operazione.</note>
+      </bibl></item>
+   <item xml:id="c2d1e7931" n="3509">
+      <label>3509.</label>
+      <bibl><author>FERNOW</author>, <title>Di Canova e delle sue opere</title>. <note>Cominciò a
+            stamparsi una riproduzione di questo rancido libercolo stampato in Svizzera molti anni
+            sono, i cui estratti si conobbero sul Giornale Enciclopedico di Napoli; e dopo <pb
+               type="cico" n="158"/> tirati gli esemplari dai primi tre fogli fino alla pagina 96,
+            fu soppressa per buon consiglio l’edizione in 12. Questo è uno dei casi in cui la
+            malevolenza ha riconosciuto la debolezza delle sue armi a fronte d’una fama
+            colossale.</note>
+      </bibl></item>
+   <item xml:id="c2d1e7945" n="3511">
+      <label>3511.</label>
+      <bibl><author>FICORONI Francesco</author>,<title> Breve descrizione di tre particolari statue
+            trovatesi in Roma l’anno 1739</title>, <pubPlace>Roma</pubPlace>
+         <date>1739</date> in 4, fig. <note>Sonovi le stampe relative al testo e trattasi di
+            monumenti singolarissimi.</note>
+      </bibl></item>
+   <item xml:id="c2d1e7963" n="3514">
+      <label>3514.</label>
+      <bibl><author>GHIBERTI Lorenzo</author>, <title>Bassi rilievi della porta maggiore del tempio
+            di S. Giovanni Battista di Firenze</title>, divisi in dieci quadri, incisi e pubblicati
+         da <publisher> </publisher>. </bibl></item>
+   <item xml:id="c2d1e7970" n="3515">
+      <label>3515.</label>
+      <bibl><author>GHIBERTI Lorenzo</author>, <title>Aggiuntovi l’incisione della stessa porta in
+            34 tavole pubblicate nel 1774 da Ferdinando de Gregori e Tommaso Patch</title>,
+            <date>1774</date>, in fol. atlant. <note>Per frontespizio a questo libro fu posta l’ara
+            di bronzo erroneamente attribuita a Ghiberti, che trovasi nella Galleria di
+            Firenze.</note>
+         <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+      </bibl></item>
+   <item xml:id="c2d1e7996" n="3518">
+      <label>3518.</label>
+      <bibl><title>GROTESQUE, cartouches, statues, des differents auteurs</title>. lume; nel quale
+         si contengono: Gli ornamenti di Simon Vovet pel Gabinetto della Regina, intagliati da
+         Dorigny; le candeliere di Decreteaux. Quelle di Polifilo Zancarli, di Audornet du Cerceau.
+         I fregi del Militelli. Gli ornati delle loggie di Rafaello mal disegnati da F. de la
+         Guertiere. Les images des Dieux des Païens; e molte altre statue antiche e moderne dalla
+         Calcografia di Mariette. <note>Freschissimo esemplare contenente in tutto 179 tavole in
+            foglio.</note>
+      </bibl></item>
+   <item xml:id="c2d1e8047" n="3526">
+      <label>3526.</label>
+      <bibl><author>MELLAN</author>, <title>Livre des statues au Palais des Tuilleries</title>,
+            <pubPlace> Paris</pubPlace>
+         <date>1678 a 1681</date>, in fol. <note>Questa è una collezione di statue e di busti
+            singolarmente intagliati a un taglio solo, non senza un certo gusto, per quanto sia
+            singolare la bizzarria. Claudio Mellan e Stefano Baudet eseguirono questo lavoro, che
+            nel nostro esemplare ascende a 63 fogli di freschissime prove.</note>
+      </bibl></item>
+   <item xml:id="c2d1e8080" n="3530">
+      <label>3530.</label>
+      <bibl><author>MILLIN</author>, <title>L’Oresteide ou dexcription de deux bas-reliefs du Palais
+            Grimani à Venise, et de quelques monumens qui ont raport à l’histoire d’Oreste</title>,
+            <pubPlace>Paris</pubPlace>
+         <date>1817</date>, in fol., fig. <note>Con 4 tav. in rame. I due monumenti, che veggonsi in
+            casa Grimani non sono altrettanto caricati come i disegni che un artista, (forse veneto)
+            esagerò nei contorni.</note>
+      </bibl></item>
+   <item xml:id="c2d1e8125" n="3537" corresp="dcl:gk7">
+      <label>3537.</label>
+      <bibl><author>PERRIER</author>, <title>Altro esemplare ove non era ancora incisa la data, di
+            prima e rarissima impressione, il quale all’infuori del frontespizio e della dedica, è
+            tutto composto di contro-prove, che servì di norma a Pietro Santi Bartoli per molte
+            stampe dell’Admiranda e dei Veteres Arcus pubblicati dal de Ross</title>i.
+      </bibl></item>
+   <item xml:id="c2d1e8131" n="3538" corresp="dcl:zfk">
+      <label>3538.</label>
+      <bibl><author>PERRIER</author>, <title>Statuae urbis Romae</title>, <pubPlace>Romae</pubPlace>
+         <date>1638</date>, in 4, constat tab. 100. </bibl></item>
+   <item xml:id="c2d1e8138" n="3539" corresp="dcl:ggk">
+      <label>3539.</label>
+      <bibl><author>PERRIER</author>,<title> Altro esemplare non completo</title>. <note>Le stampe
+            sono originali e bellissime, essendo da notarsi che vennero contraffatte le tavole e
+            riprodotte colla stessa data; ma l’occhio dell’intelligente saprà distinguerle; oltre
+            che in alcune il soggetto è rimasto a rovescio, come a cagion d’esempio nella tavola 35
+            che rappresenta il gruppo della Lotta.</note>
+      </bibl></item>
+   <item xml:id="c2d1e8144" n="3540" corresp="dcl:rc4">
+      <label>3540.</label>
+      <bibl><author>PIAZZA Giuseppe</author>, <title>Descrizione della Minerva Veliterna</title>,
+            <pubPlace>Velletri</pubPlace>
+         <date>1797</date>, in 4. </bibl></item>
+   <item xml:id="c2d1e8150" n="3541" corresp="dcl:fk7">
+      <label>3541.</label>
+      <bibl><author>PIMBIOLO Francesco</author>,<title> Pel monumento inalzato ad Alfieri in Firenze
+            da Antonio Canova</title>. Ode con annotazioni, <pubPlace>Firenze</pubPlace>, in 8, M.
+         101. <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+      </bibl></item>
+   <item xml:id="c2d1e8162" n="3542" corresp="dcl:wnw">
+      <label>3542.</label>
+      <bibl><author>PIROLI Tommaso</author>, <title>Niobes historia graecae sculpturae
+            miraculum</title>, in fol. <note>Quindici tavole, rappresentanti le statue della favola
+            di Niobe esistenti nella Galleria di Firenze, precedute da un frontespizio e da una
+            dichiarazione. Tommaso Piroli non incise forse alcuna opera con maggior gusto di queste
+            statue.</note>
+      </bibl></item>
+   <item xml:id="c2d1e8168" n="3543" corresp="dcl:608">
+      <label>3543.</label>
+      <bibl><author>PORRO Girolamo</author>,<title> Statue antiche, che sono poste nella città di
+            Roma in diversi luoghi nuovamente stampate</title>, <pubPlace>Venezia</pubPlace>
+         <date>1676</date>, in fol. pic. <note>Sono queste tavole 51, che non vennero già dal Porro
+            intagliate, ma avendo trovate le antiche lamine anche logore che altra volta furono
+            prodotte, le offerse in dono, stampandole, al senatore Giovanni Donà.</note>
+      </bibl></item>
+   <item xml:id="c2d1e8183" n="3545" corresp="dcl:5kh">
+      <label>3545.</label>
+      <bibl><author>PREISLER Jo. Justinus</author>, <title>Statuae antiquae ab Edmundo Bouchardon
+            Gallo sculptore egregio Romae delineatae a se in aes incisae</title>,
+            <pubPlace>Norimbergae</pubPlace>
+         <date>1753</date>, in fol. p. <note>Queste sono 50 statue disegnate in più piccola forma e
+            in piccolissimi foglietti, o in quarto con un frontespizio figurato e un medaglione al
+            barone di Stosch, cui sono dedicate dall’incisore. Opera fatta con gusto.</note>
+      </bibl></item>
+   <item xml:id="c2d1e8189" n="3546" corresp="dcl:b2w">
+      <label>3546.</label>
+      <bibl>
+         <title>La PSICHE Mangilliana, scolpita da Antonio Canova</title>, senza luogo e senza data,
+         M. 100. <note>Colla versione dell’Asino d’oro d’Apulejo.</note>
+      </bibl></item>
+   <item xml:id="c2d1e8220" n="3551">
+      <label>3551.</label>
+      <bibl><author>De ROSSI Giovan Gherardo</author>, <title>Aggiuntavi una lettera sulla statua
+            del Perseo. Opere di Antonio Canova</title>, <pubPlace>Pisa</pubPlace>
+         <date>1801</date>. </bibl></item>
+   <item xml:id="c2d1e8226" n="3552">
+      <label>3552.</label>
+      <bibl><author>De ROSSI Giovan Gherardo</author>, <title>In fine: una lettera dello stesso
+            sopra un quadro del cavalier Landi</title>, <pubPlace>Roma</pubPlace>
+         <pubPlace>1804</pubPlace>, in 8, M. 101. </bibl></item>
+   <item xml:id="c2d1e8390" n="3574">
+      <label>3574.</label>
+      <bibl><author>ALVERI Gasparo</author>,<title> Roma in ogni stato, alla santità di Alessandro
+            VII</title>, vol. 2, in fol., <pubPlace>Roma</pubPlace>
+         <date>1664</date>. <note>Trattasi in questi volumi de’ costumi, guerre, inondazioni del
+            Tevere, e avvenimenti relativi alla grandezza e vicende di Roma in ogni tempo, opera
+            compilata da varj autori con mediocre critica.</note>
+      </bibl></item>
+   <item xml:id="c2d1e8507" n="3590">
+      <label>3590.</label>
+      <bibl><author>BANCK L.</author>, <title>Taxa cancelleriae romanae in lucem emissa, et notis
+            illustrata. Accedit index latino-barbarus cum indice titulorum rerum, et
+            verborum</title>, <pubPlace>Franekerae</pubPlace>
+         <date>1651</date>, in 12. <note>Libro molto singolare per l’argomento, e per una serie di
+            antiche osservazioni intorno ai costumi di Roma, che si è reso raro.</note>
+      </bibl></item>
+   <item xml:id="c2d1e8570" n="3599" corresp="dcl:czn">
+      <label>3599.</label>
+      <bibl><author>BARTOLI Santi Pietro</author>, <title>Vedi fra i poeti all’articolo Virgiliani
+            Codicis Fragmenta</title>. </bibl></item>
+   <item xml:id="c2d1e8730" n="3622">
+      <label>3622.</label>
+      <bibl><author>BIONDO da Forlì</author>,<title> Roma ristaurata, ed Italia illustrata, di
+            Biondo da Forlì tradotte in buona lingua volgare per Lucio Fauno</title>,
+            <pubPlace>Vinegia</pubPlace>, per <publisher>Michele Tramezzino</publisher>,
+            <date>1548</date>, in 8. <pb type="cico" n="176"/>
+      </bibl></item>
+   <item xml:id="c2d1e8751" n="3625">
+      <label>3625.</label>
+      <bibl><author>BLONDI Flavii</author>, <title>Historiarum ab inclinatione romanorum imperii:
+            decades tres</title>, <pubPlace>Venetiis</pubPlace>
+         <date>1483</date>, in fol. Leggesi in fine: Finis historiarum Blondi quas morte praeventus
+         non complevit. Cum tamen interim Romam instauratam tribus libris, Italiam illustratam lib.
+         VIII, et Romam triumphantem lib. X absolverit. Impressum Venetiis, per
+            <publisher>Octavianum Scotum Medatiensem</publisher>, anno S. 1483 XVII kalendas Aug.,
+         Jo. Mocenigo inclyto Ven. duce. </bibl></item>
+   <item xml:id="c2d1e8783" n="3629">
+      <label>3629.</label>
+      <bibl><author>BONARDO Vincenzo Romano</author>,<title> Discorso intorno all’origine,
+            antichità, virtù, benedizione, e ceremonie, che usa il Sommo Pontefice in benedire gli
+            Agnusdei</title>, <pubPlace>Roma</pubPlace>
+         <date>1621</date>, in 8, M. 75. </bibl></item>
+   <item xml:id="c2d1e8789" n="3630">
+      <label>3630.</label>
+      <bibl><author>BORGII Hieronimi</author>, <title>Urbis Romae renovatio</title>, apud
+            <publisher>Ant. Bladum</publisher>, <date>1542</date>, in 8. Sul frontespizio è una Roma
+         sedente, a tergo alcuni versi a Pier Luigi Farnese. Segue ad III ac R. Alexandrum Farnesium
+         card. Ananeosis. Hospes. Jovius. <note>L’opera è scritta a modo di dialogo in versi.
+            Opuscolo di 22 carte raro a vedersi.</note>
+      </bibl></item>
+   <item xml:id="c2d1e8802" n="3632" corresp="dcl:qrj">
+      <label>3632.</label>
+      <bibl><author>BOSCOVICH</author>, vedi <ref>Raccolta di scrittori sulla Cupola di S.
+            Pietro</ref>. </bibl></item>
+   <item xml:id="c2d1e8814" n="3634">
+      <label>3634.</label>
+      <bibl><author>BOSIO Antonio</author>, <title>Roma sotterranea nella quale si tratta de’ suoi
+            cimiterj, del sito, forma, ed uso antico di essi ec.</title> Opera postuma pubblicata
+         dal com. <publisher>Carlo Aldobrandino</publisher>, <pubPlace>Roma</pubPlace>
+         <date>1632</date>, in f., fig. <note>Opera grande in foglio massimo, con numerosissime
+            tavole in rame, che per le arti nei bassi tempi, e per l’ecclesiastica erudizione è
+            ancor buona, sebbene i bibliografi oltramontani ne abbiamo di troppo avvilito il
+            prezzo.</note>
+      </bibl></item>
+   <item xml:id="c2d1e8820" n="3635">
+      <label>3635.</label>
+      <bibl><author>BRENNA Vincenzo architetto</author>, <title>Del tempio Tiburtino, volgarmente
+            detto della Sibilla</title>, <pubPlace>Roma</pubPlace>
+         <date>1767</date>, in fol., sono unicamente 4 fogli atlantici, uno del testo, e tre delle
+         tavole, M. 107. <note>Aggiunte in questo volume varie carte: come il progetto del sig.
+            Cockerell architetto inglese per la collocazione delle statue di Niobe; il progetto del
+            sig. Canova per la situazione dei due colossi a M. Cavallo; il mausoleo del maresciallo
+            di Saxe che vedesi a Strasburgo, opera di Pigalle, pubblicato da Mechel, e molte altre
+            stampe di genealogie ec.</note>
+         <pb type="cico" n="178"/>
+      </bibl></item>
+   <item xml:id="c2d1e8841" n="3638" corresp="dcl:q8j">
+      <label>3638.</label>
+      <bibl><author>CALVI Fabii</author>, <title>Antiquae urbis Romae cum regionibus
+            simulachrum</title>, <pubPlace>Romae</pubPlace>, mense aprili, <publisher>Valerius
+            Doricus Brixiensis</publisher> impressit, <date>1532</date>, in fol., fig. <note>Prima
+            edizione di questo raro libro, le cui tavole sono intagliate in legno</note>.
+      </bibl></item>
+   <item xml:id="c2d1e8947" n="3654">
+      <label>3654.</label>
+      <bibl><author>CAPELLI Antonii et Silvani veneti</author>, <title>Rituum ecclesiasticorum sive
+            sacrarum caeremoniarum S.S. Romanae Ecclesiae libri tres non ante impressi</title>,
+            <pubPlace>Venetiis</pubPlace>
+         <date>1516</date>, Gregorii de Gregoriis excusere Leonardo Lauredano principe optimo.
+            <note>Opera impressa in bellissimi caratteri, e con molta accuratezza di tipi.</note>
+      </bibl></item>
+   <item xml:id="c2d1e9005" n="3662">
+      <label>3662.</label>
+      <bibl><author>CELIO Gaspare</author>, <title>Memoria fatta delli nomi degli artefici delle
+            pitture che sono in alcune chiese, facciate, e palazzi di Roma</title>,
+            <pubPlace>Napoli</pubPlace>
+         <date>1638</date>, in 18. <note>Fra le guide per le pitture di Roma è una delle meno ovvie
+            a trovarsi.</note>
+      </bibl></item>
+   <item xml:id="c2d1e9083" n="3673" corresp="dcl:q59">
+      <label>3673.</label>
+      <bibl><author>CIAMPINI Joannis</author>, <title>Additamentum de veteribus monimentis</title>,
+            <pubPlace>Romae</pubPlace>
+         <date>1748</date>, in fol., fig. </bibl></item>
+   <item xml:id="c2d1e9107" n="3677" corresp="dcl:r8d">
+      <label>3677.</label>
+      <bibl><author>CLEMENTE XIII Papa</author>, <title>Cedola di moto proprio per gli ordini, e
+            regolamenti della Biblioteca, e Museo Vaticano</title>, <pubPlace>Roma</pubPlace>
+         <date>1761</date>, in 4, M. 5. </bibl></item>
+   <item xml:id="c2d1e9224" n="3693">
+      <label>3693.</label>
+      <bibl><author>CUSTODI Domin.</author>, <title>Deliciae urbis Romae divinae et humanae anno
+            sacro jubilei 1600</title>, in 4 obl., Augustae Vind. <note>Sonovi 29 tavole di romani
+            edifici, e un frontespizio figurato colle relative illustrazioni.</note>
+      </bibl></item>
+   <item xml:id="c2d1e9230" n="3694" corresp="dcl:d2m">
+      <label>3694.</label>
+      <bibl><author>DAVIDE Lodovico pittore</author>,<title> Dichiarazione della pittura della
+            cappella del Collegio Clementino in Roma</title>, <pubPlace>Roma</pubPlace>
+         <date>1695</date>, in 4, M. 37. </bibl></item>
+   <item xml:id="c2d1e9386" n="3716" corresp="dcl:pg2">
+      <label>3716.</label>
+      <bibl><author>FENESTELLA Jo. Dom. Fiocchus</author>, <title>De romanorum magistratibus, sine
+            loco et anno</title>, in 8. <note>Questa bellissima edizione del XV secolo, in caratteri
+            nitidi rotondi, e in ottima carta, non può asserirsi se preceda o segua l’altra di
+            Milano del 1477 non essendovi traccia per giudicarlo. Circa al nome di questo scrittore,
+            noi crediamo di tenerci a quanto riferiscono il Biondo, e il Fabrizio, che lo chiamano
+            Gio. Domenico, piuttosto che ad altri più moderni che il dicono Andrea. Il segretario di
+            Eugenio IV di questo casato, morì nel 1452 canonico nel duomo di Firenze.</note>
+      </bibl></item>
+   <item xml:id="c2d1e9457" n="3726" corresp="dcl:wrn">
+      <label>3726.</label>
+      <bibl><author>FIGRELII Edmundi</author>, <title>Accedit Schefferi Joan, De antiquorum
+            torquibus</title>, <pubPlace>Holmiae</pubPlace>
+         <date>1656</date>, fig. <note>La prima di queste due opere stampata in carta ottima
+            apparisce di una miglior edizione, sebbene siano gli stessi tipi. Amendue le opere sono
+            pregievolissime.</note>
+      </bibl></item>
+   <item xml:id="c2d1e9515" n="3734">
+      <label>3734.</label>
+      <bibl><author>FONTANA</author>, <title>Discorso sopra le cause delle inondazioni del Tevere
+            antiche e moderne a danno di Rom</title>a, <pubPlace>Roma</pubPlace>
+         <date>1694</date>, in 4, fig., M. 5, con 3 grandi tavole in rame. </bibl></item>
+   <item xml:id="c2d1e9638" n="3752" corresp="dcl:wjg">
+      <label>3752.</label>
+      <bibl><author>GRONOVII Jacobi</author>, <title>Dissertatio de origine Romuli</title>,
+            <pubPlace>Lugd. Batav.</pubPlace>
+         <date>1784</date>, fig., M. 55. <note>Con quattro medaglioni intagliati in rame nel
+            frontespizio.</note>
+      </bibl></item>
+   <item xml:id="c2d1e9695" n="3760">
+      <label>3760.</label>
+      <bibl><author>LAURI</author>. <title>Antiquae urbis aplendor etc.</title>
+         <note>Questa edizione divisa in tre parti soltanto, sebbene abbia un numero di tavole
+            minore delle posteriori, è di maggior pregio per la freschezza delle stampe: e poiché
+            non vi sono alcune dichiarazioni ed indici, il libro non è che di carte 132, e le parti
+            indicate portano le date come nel primo.</note>
+      </bibl></item>
+   <item xml:id="c2d1e9771" n="3771" corresp="dcl:qrj">
+      <label>3771.</label>
+      <bibl><author>MANFREDI Gabriello</author>. Vedi <ref>Raccolta di scrittori sulla cupola di S.
+            Pietro</ref>.</bibl></item>
+   <item xml:id="c2d1e9873" n="3786">
+      <label>3786.</label>
+      <bibl><author>MARTINELLI Giovanni</author>, <title>Le cose meravigliose della città di Roma
+            ec.</title>, <pubPlace>Roma</pubPlace>
+         <date>1589</date>, in 8. <bibl>— <title>Aggiuntovi: L’antichità di Roma di M. Andrea
+               Palladio</title>, <pubPlace>Roma</pubPlace>, <date>1589</date>, per
+               <publisher>l’Accolti</publisher>, in 8.</bibl>
+         <bibl>— <title>Di più: I nomi antichi, e moderni dell’antica città di Roma</title>,
+               <pubPlace>Venezia</pubPlace>
+            <date>1552</date>, in 8.</bibl>
+         <bibl>— <title>E in fine, alcune osservazioni manoscritte</title>.</bibl>
+      </bibl></item>
+   <item xml:id="c2d1e9900" n="3790">
+      <label>3790.</label>
+      <bibl><author>MENETREI Claudii Francisci</author>, <title>Columna Theodosiana quam vulgo
+            historiatam vocant ab Arcadio imperatore Costantinopoli erecta in honorem imperatoris
+            Theodosii junioris a Gentile Bellino delineata nunc primum aere sculpta et in XVIII tab.
+            distributa</title>, senza luogo ed anno, in foglio m. obl. <note>Nell’occasione che
+            Gentile Bellino fu chiamato a Costantinopoli da Maometto II voglioso di avere il proprio
+            ritratto, e di vedere alcune pitture, questo artefice fece i disegni di un tal monumento
+            che dimostra la decadenza al V secolo, ma non lascia interamente dimenticare le altre
+            preesistenti colonne trionfali di Roma. Il Menetrejo racconta nelle spiegazioni che i
+            disegni originali di Gentile erano lunghi 52 piedi, ed erano passati in Francia nel
+            Museo Accarti a Parigi, e furono recati in questa dimensione da un pittore chiamato
+            Paillet, acciò un certo Velletti intagliatore e pensionato in Roma dell’Accademia di
+            Francia potesse facilmente intagliarli.</note>
+      </bibl></item>
+   <item xml:id="c2d1e9933" n="3794">
+      <label>3794.</label>
+      <bibl><title>MIRABILIA Romae</title>. <note>Noi possiamo qui presentare tre esemplari i più
+            rari di questo libretto, che per la sua celebrità tien luogo fra i cimelj più importanti
+            dell’antichità, giacché serve moltissimo a dinotare i principali oggetti di curiosità,
+            che in quell’epoca avevano pregio in Roma, e il modo in cui dall’ignoranza volgare
+            venivano apprezzati. Due di questi nostri esemplari sembrano evidentemente editi da
+            Adamo Rot, e particolarmente a ciò ne conduce oltre la forma dei caratteri il notare che
+            il terzo pubblicato da Gerardus Flandria nel 1475 in Trevigi, non può essere che una
+            ristampa di quelli che erano esciti in Roma col mezzo de’ primi stampatori i quali colà
+            introdussero l’arte. L’uno però di questi due più antichi esemplari è in sei carte in 8
+            e l’altro è in otto. Cominciando dal primo, che ha l’apparenza della maggiore antichità,
+            e a primo aspetto direbbesi xylografo, ecco l’ordine dei capitoli. Mirabilia Romae
+            incipiunt. De portis infra urbem. De portis transtiberim. De montibus infra urbem. De
+            pontibus urbis Romae. Palacia imperatorum sunt hec. De arcubus non triumphalibus. De
+            thermis. De theatris. De agulea Sancti Petri. De cimiteriis. Loca ubi sancti passi sunt
+            tormenta. Ad Sanctam Agatham. De templis. De equis marmoreis. De femina circumdata
+            serpentibus. De rustico sedente super equum. Sequitur de Colliseo. De Sancta Maria
+            rotunda. De Octaviano imperatore. Mirabilia Romae finiunt. Simile al qui descritto è
+            l’esemplare della Biblioteca Corsini in Roma, dall’Audifredi appunto riconosciuto
+            impresso coi caratteri di Adamo Rot. Il secondo esemplare, egualmente senza data,
+            stampato in otto carte, ma con caratteri più rotondi, sebbene alla prima edizione
+            rassomiglianti in gran parte, e prodotto con miglior cura nell’assettamento dei tipi, è
+            parimenti in ottavo, in grande, e bellissima forma, e i capitoli sono ordinati nel modo
+            seguente: Mirabilia Romae. De portis infra urbem. De portis transtiberim. De montibus
+            infra urbem. De pontibus urbis Romae. Palacia imperatorum. De arcubus triumphalibus. De
+            terminis. De theatris. De agulea Sancti Petri. De cimiteriis. Ad Sanctam Agatham. De
+            pinea aerea et deaurata. De templis. De equis marmoreis. De femina circumdata
+            serpentibus. De rustico sedente super aereum equum. Sequitur de Coliseo. De Sancta Maria
+            rotunda. De Octaviano imperatore. Totilae exasperatio in servos Dei. Deo Gratias. I
+            titoli dei capitoli sono stampati in majuscole fino a quello de theatris inclusive, e
+            gli altri sino al fine in piccoli caratteri. Le altre varietà, i capitoli riuniti, e gli
+            aggiunti si riconoscono evidentemente. <pb type="cico" n="203"/> L’ultimo, e il più
+            bello dei nostri esemplari per l’eleganza dei tipi, è quello del 1475 citato dal Panzer
+            negli Annali tipografici, che non sappiamo esistere in alcuna biblioteca di Roma. Questo
+            è composto di nove carte numerate nella sommità con numeri romani dall’I al IX impresso
+            con bellissimi caratteri, e coi capitoli così distribuiti: Mirabilia Romae. De portis
+            infra urbem. De portis transtiberim. De montibus infra urbem. De pontibus urbis Romae.
+            Palacia imperatorum. De arcubus triumphalibus. De arcubus non triumphalium. De thermis.
+            De theatris. De agulea Sancti Petri. De cimiteriis. Ad Sanctam Agatham. De Pinea aerea
+            et deaurata. De templis. De equis marmoreis. De femina circumdata serpentibus. De
+            rustico sedente super equum aereum. De Coliseo. De Sancta Maria rotunda. De Octaviano
+            imperatore. Totilae exasperatio in servos Dei. Finis Laus Deo. 1475 12 aprilis Tarvisii.
+            G. F. (cioè Gherardus de Flandria). Non avvi altra varietà tra quest’ultimo e il
+            precedente, se non l’errore de terminis correggendo de termis, il che maggiormente
+            sembra confermare che quelli senza data sopra citati sieno anteriori: se ne pubblicarono
+            in seguito ogni momento, e si riunivano ai libretti delle indulgenze fintanto che
+            Francesco Albertino fu il primo a separarli, e vendicarli dalle stoltezze ridicole di
+            cui per volgari pregiudizj erano ripieni. E questi libretti erano impressi
+            cumulativamente nel titolo Mirabilia et indulgentiae urbis Romae, come leggesi in un
+            esemplare stampato dal Blado a spese di Mazocchio coll’arme di Leon X papa, vale a dire
+            nella seconda diecina circa del XVI secolo. Copiosissimi divenuti dunque nel principio
+            del 1500 pel concorso dei forestieri, per la facilità della stampa, e per lo splendore
+            che andò riacquistando Roma stessa sotto i celebri pontificati di Giulio, e di Leone,
+            durarono però lungamente ad essere confusi coi libercoli detti da Istoriaro, o vendi
+            istorie di cui erano avidissimi i pellegrini che visitavano i santuarj; e questi
+            libretti portavano i titoli di Indulgentiae ecclesiarum urbis Romae. Modus confitendi.
+            Divisiones decem nationum. Orationes S. Brigittae. Tabula cristiana. Conjuratio
+            malignorum spirituum. Descriptio domus Lauretanae etc. etc. Ma è più singolare l’unione
+            curiosa dei memorabilia ai mirabilia Romae come abbiamo in più luoghi osservato, e a
+            nostro agio potuto riconoscere maggiormente nella reale e ricchissima Biblioteca di
+            Monaco ove ci è stato forza l’ammettere l’esistenza di parecchi xylografi anche molti
+            anni dopo l’uso divulgatissimo delle stampe in torchio coi metodi in uso al presente.
+            Piacerà trovar qui riportato alcun squarcio estratto dallo stesso regio bibliotecario
+            sig. Scherer da un xylografo che porta l’arme di Giulio II col triregno, e due targhe,
+            l’una colle chiavi, l’altra <fw type="foot"/>
+            <pb type="memofonte"/>
+            <fw type="head"/> coll’S.P.Q.R. Al di sopra due angeli sostengono un pannicello
+            coll’impronta d’un sudario. <pb type="cico" n="204"/> Le parole del frontespizio sono
+            Memorabilia urbis Romae. Leggesi nel primo foglietto retto come segue. “Item in questo
+            libretto sta escritto come Roma fu fabbricata, e dal primo re, e da ciascun re di Roma,
+            come hanno governato, e come ancora i romani nissun re più non volevano, ed interruppero
+            con capitani e consoli per lungo tempo. Dal primo Giulio Cesare, e da tutti i Cesari in
+            Roma, come hanno governato fin ai tempi di Cesare Costantino, come il Cesare Costantino
+            fu battezzato, e mondato dalla Lepra; come dié al Papa S. Silvestro la città di Roma, ed
+            il paese di intorno a lui ed a tutti suoi posteri, e pose lui ed i suoi posteri per capo
+            a tutti i cristiani, quale chiese in Roma sono, e qual cose sante, e perdoni nelle
+            chiese tutte; tutte le stazioni nella chiese durante l’anno.” Nel detto foglio verso si
+            contiene la rappresentazione della città di Roma con Rea e la Lupa. Foglio secondo
+            retto, Roma civitas sancta caput mundi. “Dal principio del mondo 1450 anni quando Troja
+            fu disfatta dall’Imperador Greco, e che i principi ed i signori se ne fuggivano dalla
+            gran città di Troja per mare con molti beni in questi paesi fabbricarono città, e
+            castelli; allora vennero di quei signori anche nei itali paesi, là dove adesso si trova
+            la città di Roma. Avenne questo ai tempi del re di Giuda Gioachino. In quei tempi vi era
+            una giovane Rea di nome, figlia del re dei sette monti, dove adesso Roma sta edificata.
+            Questa giovine quando fu nel tempio dell’Idolo Vesto, venne ad ella la pianeta Marte, ed
+            ebbe a fare con ella nascostamente. Di là nacquero due gemelli l’uno chiamato Remo,
+            l’altro Romolo.” Nel foglio ultimo. “Allora fece dono il Cesare (Costantino) a S.
+            Silvestro e a tutti suoi posteri, e gli diede la città di Roma, ed il paese, e molte
+            città. Ebbe qui fine ancora la gran proscrizione de’ cristiani, ed i cristiani
+            incominciarono ad aumentarsi, e da questo tempo in qua non è più stata tanta
+            proscrizione. È vero che si sono levati poi dei falsificatori della vera fede, come gli
+            Arriani, ed altri eretici. Questi coll’ajuto di Dio sono stati disfatti da Gregorio,
+            Geronimo, Augustino, Ambrosio. Costantino se n’andò in Grecia, e colà fabbricò una
+            grande città, e la chiamò secondo lo stesso Costantinopoli, ed in quanto a Roma la
+            lasciò al Papa.” Nell’anno 1482 Jean Schawer a Monaco pubblicò un’altra edizione in
+            tedesco Memorabilia Romae unito ai mirabilia e tanto nella prima verosimilmente eseguita
+            in Roma ed intitolata al Papa, quanto in un’altra di Roma del 1492 per Magistrum
+            Stephanorum Planneck de Patavia in fronte a cui stanno gli stemmi di Alessandro VI viene
+            riportata la storia della papessa Giovanna. Anche in una terza edizione del memorabilia
+            con molte variazioni dalle precedenti, stampata in Roma precisamente nel 1515 a cui
+            vanno uniti i mirabilia, et le indulgenze è ripor <pb type="cico" n="205"/> tata la
+            detta storia della papessa Giovanna all’articolo ad Sanctum Clementem in questi termini.
+            Item habetur in serie Romanorum Pontificum quod Johannes Anglicus post Leonem sedit
+            annis duobus, mensibus quinque, et diebus quatuor, vacavit sedes mense uno, ut asseritur
+            femina fuit, et juvenili habitu ab amante suo Athenis ducta: in diversis scientiis
+            tantum profecit; ut Romae tandem legeret ad triennium, et magnos magistros haberet
+            discipulos: nec sibi quisquam similis ibidem ineveniebatur. Magne itaque scientiae, et
+            opinionis existens in Papam concorditer elegitur: sed in papatump per familiarem
+            impregnatur. Verum tempus partus ignorans: de sancto Petro in Lateranum tendens;
+            angustiata peperit inter Coliseum, et sanctum Clementem, et ibidem, ut dicitur, moritur.
+            Hanc viam quando Papa obliquat, dicitur a plerisque quod propter detestationem fasti hoc
+            fiat; nec ponitur in catalogo Pontificum, propter mulierem sexum (sic) quantum ad hanc
+            difformitatem. Gli stemmi di Leon X stanno impressi nel volumetto singolare, e ben aveva
+            ragione il cardinal Galeotto di scrivere a Francesco Albertino: Quare mirabilia Romae
+            imperfecta, fabularumque nugis plena non corrigus? Ma però questo da noi riportato si
+            vede impresso in Roma stessa cinque anni dopo che era già stampato il libro
+            dell’Albertini, sotto un gran pontificato, e in tempo di molti lumi sparsi nel secolo.
+            La censura delle stampe non esercitava certamente in allora una rigorosa
+            disciplina.</note>
+      </bibl></item>
+   <item xml:id="c2d1e9968" n="3797">
+      <label>3797.</label>
+      <bibl><author>MODIO Giovan Battista</author>, <title>Il Tevere, dove si ragiona in generale
+            della natura di tutte le acque, e in particolare di quella del fiume di Roma</title>,
+            <pubPlace>Roma</pubPlace>, presso <publisher>Vincenzo Luchino</publisher>,
+            <date>1556</date>, in 8, M. 75. <note>Operetta ben stampata, divisa in due libri,
+            dedicata al cardinale Ranuccio Farnese. L’autore era un medico calabrese <pb type="cico"
+               n="206"/> discepolo di san Filippo Neri, che scrisse le annotazioni ai cantici di
+            Jacopone da Todi, e stampò un’opera intitolata il Convitto, ovvero del peso della
+            moglie, in Milano 1558, in 8.</note>
+      </bibl></item>
+   <item xml:id="c2d1e9995" n="3801">
+      <label>3801.</label>
+      <bibl><author>NELLI G. B.</author>, Vedi<ref> Raccolta di scrittori sulla Cupola di S.
+            Pietro</ref>. </bibl></item>
+   <item xml:id="c2d1e10175" n="3827">
+      <label>3827.</label>
+      <bibl><author>PIRANESI</author>, <title>Opere varie di architettura, prospettive, grotteschi,
+            ed antichità sul gusto degli antichi romani, inventate, ed incise</title>,
+            <pubPlace>Roma</pubPlace>
+         <date>1750</date>. <note>Sono 34 tavole compreso il frontespizio. Poi seguono 16 gran
+            tavole di carceri: indi la prima parte dell’antichità romane dei tempi della Repubblica
+            in 29 tavole col frontespizio. In fine di questo volume trovansi i Trofei di Ottaviano
+            Augusto cogli altri Frammenti di Antichità, Roma 1753, fol. massimo. Sono 9 gran tavole
+            col frontespizio.</note>
+      </bibl></item>
+   <item xml:id="c2d1e10181" n="3828" corresp="dcl:pk1">
+      <label>3828.</label>
+      <bibl><author>PIRANESI</author>, <title>Le antichità romane divise in 4 tomi</title>,
+            <pubPlace>Roma</pubPlace>
+         <date>1756</date>, in fol. mas. <note>Quest’opera delle antichità romane è divisa in 4
+            volumi, nel primo de’quali si dimostrano gli avanzi degli antichi edifizj, acquedotti,
+            terme, foro romano ec. Nel secondo che contiene 63 tav., e nel 3 che ne contiene 54, gli
+            avanzi dei monumenti sepolcrali i Roma, e nell’agro romano, sarcofagi, cippi, bassi
+            rilievi ec. Nel 4 i ponti antichi, teatri, portici, altri monumenti ec. in 57
+            tavole.</note>
+      </bibl></item>
+   <item xml:id="c2d1e10188" n="3829">
+      <label>3829.</label>
+      <bibl><author>PIRANESI Giovan Battista </author> architetto veneziano, <title>Vedute di Roma
+            disegnate, ed incise</title>. <note>Questo potrebbe essere un quinto volume alle
+            antichità romane se non fossero quivi intagliate anche alcune fabbriche moderne in 54
+            tavole, compreso il frontespizio.</note>
+      </bibl></item>
+   <item xml:id="c2d1e10233" n="3835">
+      <label>3835.</label>
+      <bibl><author>PIRANESI</author>, <title>Antichità di Albano, e di Castel Gandolfo incise, e
+            descritte</title>, <pubPlace>Roma</pubPlace>
+         <date>1764</date>, in fol. mas. <note>Le antichità contengono 26 tavole, alle quali segue
+            la descrizione e disegno dell’emissario del lago di Albano con 9 grandi tavole, poi
+            vengono le due spelonche ornate dagli antichi alla riva del lago in tavole 12.</note>
+      </bibl></item>
+   <item xml:id="c2d1e10272" n="3841" corresp="dcl:92p">
+      <label>3841.</label>
+      <bibl><author>POCH Bernardo</author>, <title>De’ marmi estratti dal Tevere, e delle iscrizioni
+            scolpite in essi a S. E. il principe Altieri, lettera</title>, <pubPlace>Roma</pubPlace>
+         <date>1773</date>, in 4, M. 1, e 27. <note>Non è che un foglietto in stampa.</note>
+      </bibl></item>
+   <item xml:id="c2d1e10466" n="3868">
+      <label>3868.</label>
+      <bibl><author>De ROSSI Filippo</author>, <title>Ritratto di Roma moderna distinto in
+            quattordici rioni con figure</title>, <date>1689</date>, in 8, vol. 2. <note>Questi due
+            volumi assai ben fatti viddero la luce la prima volta nel 1645 per opera di Filippo de
+            Rossi, e vennero riprodotti da Michel Angelo Rossi, negli anni indicati: sonovi anche
+            molte stampe in rame, e massimamente sono migliori quelle di Roma moderna.</note>
+      </bibl></item>
+   <item xml:id="c2d1e10530" n="3877">
+      <label>3877.</label>
+      <bibl><author>SANTINI P.</author>, <title>Vedi raccolta di scrittori sulla cupola di S.
+            Pietro</title>. </bibl></item>
+   <item xml:id="c2d1e10569" n="3883">
+      <label>3883.</label>
+      <bibl>
+         <title>SECONDE partie du premier livre des curiositéz de l’une et de l’autre Rome, en la
+            quelle il est traité de sept notables eglises qui y sont dediées à la très Sainte Vierge
+            etc.</title>, a <pubPlace>Paris</pubPlace>
+         <date>1558</date>, in 8, fig., M. 75. <note>Questa è una delle più antiche guide di Roma
+            stampate per comodo de’ forestieri che viaggiavano di Francia in Italia e doveva essere
+            composta di più volumetti.</note>
+         <pb type="cico" n="220"/>
+      </bibl></item>
+   <item xml:id="c2d1e10589" n="3886">
+      <label>3886.</label>
+      <bibl>
+         <title>SPECULUM romanae magnificentiae, omnia fere quaecumque in urbe monumenta extant,
+            partim juxta antiquam, partim juxta hodiernam formam accuratissime delineata
+            repraesentans</title>, excussa ab Antonio Laferio, <pubPlace>Romae</pubPlace>, in fol.
+         m., fig. <note>Sono questi monumenti, piante, prospetti, fragmenti, e ristaurazioni
+            d’antichi edifici, e statue ec. Alcuni cataloghi di stampe citano questa collezione come
+            se fosse composta di un determinato numero di tavole, e trovasi in qualche luogo
+            precisata a 118. Noi però riconosciamo un’infinita varietà in tutti gli esemplari veduti
+            che privi di <fw type="foot"/>
+            <pb type="memofonte"/>
+            <fw type="head"/> testo, e di numero, alle lamine non vennero accumulati se non per cura
+            dei raccoglitori: sono queste le prime e più rare tavole delle antichità romane che
+            abbiamo nella nostra collezione in due volumi separati, poiché in questo ne stanno 93, e
+            114 ne stanno al seguito dell’edizione del Labacco senza luogo ed anno, in tutto 207. I
+            principali calcografi di questa collezione assai preziosa furono Antonio Lafreri,
+            Antonio Salamanca, Enrico Van Schoel, e Niccolò Van Aelst. Ma s’incontrano tavole
+            pregiatissime di Antonio Tempesta, Sisto Badalocchi, Giacomo Bossio, Diana Mantovana, P.
+            Perret, Enea Vico, Niccolò Beatricio Lotaringio, Luigi Rouhier, ed altri: sempre questi
+            due nostri esemplari si vanno aumentando.</note>
+      </bibl></item>
+   <item xml:id="c2d1e10655" n="3895">
+      <label>3895.</label>
+      <bibl><author>VANNI Bartolommeo</author>. <title>Vedi Raccolta di scrittori sulla cupola di S.
+            Pietro</title>.</bibl></item>
+   <item xml:id="c2d1e10800" n="3916">
+      <label>3916.</label>
+      <bibl><author>VISCONTI Ennio Quirino</author>, <title>Monumenti Galbinj della villa Pinciana
+            descritti</title>, <pubPlace>Roma</pubPlace>
+         <date>1797</date>, in 8, fig. </bibl></item>
+   <item xml:id="c2d1e10814" n="3918" corresp="dcl:460 dcl:snx dcl:g2p dcl:krr">
+      <label>3918.</label>
+      <bibl><author>ZACCARIAE Franc. Ant.</author>, <title>Dissertationes in S. Flavii Clementis
+            tumulum; in S. Marii et Alexandri epitaphiis</title>; de S. Barbarae Nicomediensis
+         cultu; de inventione S. Crucis, in 4, M. 30. </bibl></item>
+   <item xml:id="c2d1e10821" n="3919">
+      <label>3919.</label>
+      <bibl><author>ZANONI Francesco</author>, <title>Ragguaglio della nuova pittura del signor
+            Filippo Gherardi da Lucca sulla volta e tribuna della chiesa di S. Pantaleo scoperta
+            l’anno <date>1690</date></title>, <pubPlace>Roma</pubPlace>, in 8, M. 62. </bibl></item>
+   <item xml:id="c2d1e10916" n="3931" corresp="dcl:rzm">
+      <label>3931.</label>
+      <bibl><author>AMADUTIO Jo. Christoph.</author>, <title>Francisci Aligeri Dantis III filii
+            Dialogus de antiquitatibus Valentinis ex cod. memb. saec. XVI nunc primum in lucem
+            editus</title>, <pubPlace>Romae</pubPlace>
+         <date>1773</date>, in 8, M. 61. </bibl></item>
+   <item xml:id="c2d1e10961" n="3937">
+      <label>3937.</label>
+      <bibl><author>ANTOLINI Giovanni</author>, <title>Descrizione del Foro Bonaparte</title>,
+            <pubPlace>Parma</pubPlace>, co’ tipi <publisher>bodoniani</publisher>,
+         <date>1806</date>, M. 85. <note>Opera di grandiosa immaginazione stampata con tutta
+            l’eleganza dei tipi, e lo splendore dell’incisione. Il testo fu esteso da Pietro
+            Giordani, e le tavole sono in numero di 24 in foglio grande atlantico.</note>
+      </bibl></item>
+   <item xml:id="c2d1e10986" n="3941" corresp="dcl:h8f">
+      <label>3941.</label>
+      <bibl><title>Le ARME ovvero le insegne di tutti i nobili della magnifica ed illustrissima
+            città di Venezia che ora vivono</title>, <pubPlace>Venezia</pubPlace>
+         <date>1541</date>, in 4. </bibl></item>
+   <item xml:id="c2d1e10992" n="3942">
+      <label>3942.</label>
+      <bibl><title>ATLANTE di tavole per la storia del terremoto della Calabria</title>, in fol.
+         oblong. <note>Sono 68 tavole in rame ove è tutta espressa la Calabria, e <pb type="cico"
+               n="229"/> in fine è la gran carta calcografica del p. Eliseo composta di molti fogli
+            riuniti colle indicazioni de’ villaggi danneggiati o distrutti.</note>
+      </bibl></item>
+   <item xml:id="c2d1e11024" n="3946" corresp="dcl:tbs">
+      <label>3946.</label>
+      <bibl><author>BALDI Bernardino da Urbino monsignor</author>,<title> Versi, e prose</title>,
+            <pubPlace>Venezia</pubPlace>, presso <publisher>il Franceschi</publisher>,
+            <date>1590</date>, in 4. <note>Trovasi in questo volume la descrizione del palazzo
+            d’Urbino in prosa con altre opere, che venne poi ristampata in foglio nel 1734. Tutti
+            gli scritti di questo autore dottissimo sono preziosi.</note>
+      </bibl></item>
+   <item xml:id="c2d1e11070" n="3953">
+      <label>3953.</label>
+      <bibl><author>BERGIER Nicolas</author>, <title>Le dessein de l’histoire de Reims avec diverses
+            curieuses remarques touchant l’establissement des peuples et la fondation des villes de
+            France</title>, a <pubPlace>Reims</pubPlace>
+         <date>1635</date>. <note>Sonovi 5 tavole intagliate in rame, e l’opera è estesa con
+            infinita critica, e buon tatto.</note>
+      </bibl></item>
+   <item xml:id="c2d1e11121" n="3960">
+      <label>3960.</label>
+      <bibl><author>La BORDE Aléxandre</author>, <title>Description d’un pavé en mosaïque découvert
+            dans l’ancienne ville d’Italica, aujourdhui le village de Santinponce près de cette
+            ville</title>, a <pubPlace>Paris</pubPlace>, <date>1802</date>,
+            <publisher>Didot</publisher>, in fol. atlantico miniato. <note>Edizione di massimo lusso
+            tirata nel solo numero di 160 esemplari: sonovi 103 pagine di testo, e 22 grandi tavole,
+            non contando le molte vignette, e altri monumenti illustrativi.</note>
+      </bibl></item>
+   <item xml:id="c2d1e11127" n="3961">
+      <label>3961.</label>
+      <bibl><author>BOREL Pierre conseiller et med. du Roy</author>, <title>Tresor des recherches et
+            antiquités gauloises et françoi <pb type="cico" n="232"/> ses reduites en ordre
+            alphabetique etc.</title>, <pubPlace>Paris</pubPlace>
+         <date>1655</date>, in 4. </bibl></item>
+   <item xml:id="c2d1e11231" n="3976">
+      <label>3976.</label>
+      <bibl><author>CAMPBELL</author>. <bibl>Vedi <author>Vitruvius</author>
+            <title>Britannicus</title>.</bibl></bibl></item>
+   <item xml:id="c2d1e11258" n="3979" corresp="dcl:568">
+      <label>3979.</label>
+      <bibl><author>CARLI Giovan Rinaldo</author>, <bibl>Vedi <title>delle Antichità romane</title>
+            etc.</bibl></bibl></item>
+   <item xml:id="c2d1e11270" n="3981">
+      <label>3981.</label>
+      <bibl><author>CAROTO Giovanni pittor veronese</author>, <title>Antichità di Verona da lui
+            disegnate, e nuovamente date in luce</title>, <pubPlace>Roma</pubPlace>, nella stamperia
+            de<publisher>i fratelli Merlo</publisher>, <date>1746</date>, in fol., fig., <bibl>vedi
+               <author>Saraine</author> etc.</bibl></bibl>
+      <note>Sono qui riprodotte le trentauna tavole in legno del Saraina in tutta dimensione
+         precedute da tre avvisi, uno dello stampatore, uno del Saraina, l’altro di Giovanni Caroto
+         ai lettori, e da un indice delle tavole.</note>
+   </item>
+   <item xml:id="c2d1e11309" n="3987">
+      <label>3987.</label>
+      <bibl><author>CICOGNARA</author>, <title>Le fabbriche più cospicue di Venezia, misurate,
+            illustrate ed intagliate dai membri della veneta R. Accademia di Belle Arti</title>,
+            <pubPlace>Venezia</pubPlace>, <publisher>Tipografia Alvisopoli</publisher>, <date>1815
+            al 1820</date>, fig., vol. 2, in fol. mass.</bibl>
+      <note>Questa grand’opera contiene 250 tavole colle piante, spaccati, e prospetti de’ più
+         insigni edfizj di Venezia di ogni età, accompagnati da dissertazioni storiche, e critiche,
+         in molte delle quali concorsero oltre l’autore già indicato, il nob. <pb type="cico"
+            n="237"/> uomo Antonio Diedo segretario dell’Accademia, e il defunto professore Antonio
+         Selva, ambedue nell’architettura peritissimi.</note>
+   </item>
+   <item xml:id="c2d1e11459" n="4008">
+      <label>4008.</label>
+      <bibl><author>FENDT Tobiae</author>, <title>Monumenta clarorum doctrina praecipue toto orbe
+            terrarum virorum collecta passim et maximo impendio cura et industria in aes incisa,
+            sumptu et studio nobilis viri D. Sigefridi Rybisch, opera vero Tobiae Fendt civis et
+            pictoris uratislaviensis etc.</title> Editio tertia longe absolutissima,
+            <pubPlace>Francf. ad M.</pubPlace>, impensis <publisher>Sigismundi
+            Feirabendt</publisher>, <date>1589</date>, in fol. <note>Sono queste 126 tavole compreso
+            il frontespizio figurato e intagliato in rame da Jodoco Amano Tigurino come per la sua
+            marca, e lo stile si riconosce, le quali presentano una preziosa serie di monumenti ed
+            iscrizioni lapidarie tratte dalle principali città d’Italia. Opera di qualche rarità, la
+            quale conserva alcune memorie già perite e disperse.</note>
+      </bibl></item>
+   <item xml:id="c2d1e11543" n="4020">
+      <label>4020.</label>
+      <bibl><author>GORI Anton Francesco</author>, <title>Descrizione della cappella di S. Antonio
+            nella chiesa di S. Marco di Firenze presentata da Alamanno Salviati a Benedetto
+            XIII</title>, <pubPlace>Firenze</pubPlace>
+         <date>1728</date>, in fol., fig. <note>Con otto tavole in rame intagliate da Bernardo
+            Sgrilli, e dal Ruggieri.</note>
+      </bibl></item>
+   <item xml:id="c2d1e11594" n="4027">
+      <label>4027.</label>
+      <bibl><title>L’ITALIE illustrée en 135 figures en tailles donces en fol. dessinées, et gravées
+            par les plus fameux graveurs des Pays Bas, avec l’explication en italien, françois, et
+            latin</title>, <pubPlace>Leyde</pubPlace>, chez Hank, <date>1757</date>. <note>Potrebbe
+            questo libro piuttosto intitolarsi come apparisce da un secondo frontespizio, Vedute di
+            Venezia; poiché quasi tutto il volume è consacrato a questa città: rappresentata in 115
+            tavole, non ne restando che 20 alle vedute di altre principali città dell’Italia.</note>
+      </bibl></item>
+   <item xml:id="c2d1e11619" n="4031">
+      <label>4031.</label>
+      <bibl><author>LITTA Pompeo</author>, <title>Famiglie celebri d’Italia</title>,
+            <pubPlace>Milano</pubPlace>, <date>1819</date>, presso <publisher>Paolo Emilio
+            Giusti</publisher>, in fol., fig.</bibl>
+      <note>Opera grandiosa, e una delle più insigni che si pubblichi <pb type="cico" n="244"/> no
+         in Italia. Esce a fascicoli separati, ogni fascicolo contiene una o più famiglie. Le
+         medaglie che servono d’illustrazione sono tratte da musei, i monumenti dal vero. I
+         fascicoli si danno uniti, e separati, a piacere; non vi è associazione: un autore nobile e
+         indipendente non deve avere vincoli comuni agli editori mercenarj (così l’autore protesta).
+         In questo primo fascicolo è illustrata la famiglia Attendolo Sforza: sono 31 carte fra le
+         quali trovansi sedici stampe di medaglie e monumenti copiosissime eseguite con la massima
+         diligenza e fedeltà, non potendosi mai lodare abbastanza la solerzia dell’autore nell’esame
+         de’ materiali per tutte le storiche erudizioni di cui l’opera laboriosissima è ripiena. M.
+         105.</note>
+   </item>
+   <item xml:id="c2d1e11825" n="4060">
+      <label>4060.</label>
+      <bibl><author>PAOLINO da S. Bartolommeo</author>, <title>Viaggio alle Indie Orientali umiliato
+            alla Santità di Pio VI</title>, <publisher>Roma</publisher>
+         <date>1796</date>, in 4, fig. <note>Sono alcune tavole collocate fra il testo. Opera non
+            dettata da buona critica.</note>
+      </bibl></item>
+   <item xml:id="c2d1e11942" n="4077">
+      <label>4077.</label>
+      <bibl><author>RANGIASCHI Sebastiano</author>, <title>Del tempietto di Marte Ciprio, e de’ suoi
+            monumenti dissotterrati nella campagna di Gubbio l’anno 1781</title>,
+            <pubPlace>Gubbio</pubPlace><date> 1784</date>, in 12, figurato. </bibl></item>
+   <item xml:id="c2d1e11967" n="4080" corresp="dcl:q2g">
+      <label>4080.</label>
+      <bibl><author>RICHARDSON Giorgio</author>. Vedi <ref>Vitruvius Britanicus</ref>.</bibl></item>
+   <item xml:id="c2d1e12006" n="4086" corresp="dcl:ng3">
+      <label>4086.</label>
+      <bibl><author>SALVIATI Alamanno</author>, <title>Descrizione della cappella di S. Antonino
+            arcivescovo di Firenze</title>, <pubPlace>Firenze</pubPlace>
+         <date>1728</date>, in fol., fig. </bibl></item>
+   <item xml:id="c2d1e12272" n="4123">
+      <label>4123.</label>
+      <bibl><author>WOLFE</author> e <author>GANDON</author>. Vedi <ref>Vitruvius
+         Britannicus</ref>.</bibl></item>
+   <item xml:id="c2d1e12284" n="4125" corresp="dcl:062">
+      <label>4125.</label>
+      <bibl><author>WORM Olai D.</author>,<title> Regum Daniae series duplex et limitum inter Daniam
+            et Sveciam descriptio</title>, <pubPlace>Hafniae</pubPlace>
+         <date>1640</date>, in f. </bibl>
+   </item>
+   <item xml:id="c2d1e12338" n="4131">
+      <label>4131.</label>
+      <bibl><author>BARRI Giacomo</author>, <title>pittore in Venezia, Viaggio pipttoresco in cui si
+            notano le più famose pitture dell’Italia</title>, <pubPlace>Venezia</pubPlace>
+         <date>1671</date>, in 12. </bibl></item>
+   <item xml:id="c2d1e12377" n="4137">
+      <label>4137.</label>
+      <bibl><author>ERBA (dall’) Giovanni</author>, <title>Itinerario delle poste per diverse parti
+            del mondo ed il viaggio di S. Giacomo di Galizia con tutte le fiere notabili che si
+            fanno per tutto il mondo, con una narrazione delle cose di Roma, e massime delle sette
+            chiese</title>, <pubPlace>Venezia</pubPlace>
+         <date>1564</date>, in 16. </bibl></item>
+   <item xml:id="c2d1e12486" n="4152" corresp="dcl:dk7">
+      <label>4152.</label>
+      <bibl><author>VENNI Giuseppe</author>,<title> Elogio storico delle gesta del R. oderico
+            dell’ordine de’ MM. CC. colla storia dei <pb type="cico" n="264"/> suoi viaggi asiatici,
+            illustrata</title>, <pubPlace>Venezia</pubPlace>
+         <date>1761</date>, in 4, fig. </bibl></item>
+   <item xml:id="c2d1e12641" n="4166" corresp="dcl:dp9">
+      <label>4166.</label>
+      <bibl><title>GUIDE de Berlin, de Postdam et des environs: traduit de l’allemand avec un plan
+            de Berlin et 15 vues</title>, <pubPlace>Berlin</pubPlace>
+         <date>1813</date>, in 8, fig. </bibl></item>
+   <item xml:id="c2d1e12647" n="4167">
+      <label>4167.</label>
+      <bibl><title>NOTICE raisonnée d’une partie des tableaux qui se trouvent dans le magazin de la
+            librairie du Roi <pb type="cico" n="266"/> precedé d’observations sur la connoissance et
+            le commerce des tableaux</title>, <pubPlace>Berlin</pubPlace>
+         <date>1804</date>, in 8.</bibl></item>
+   <item xml:id="c2d1e12676" n="4170" corresp="dcl:9p1">
+      <label>4170.</label>
+      <bibl><author>CROCE M. Giulio Cesare</author>, <title>Descrizione del nobil palazzo posto
+            nella contà di Bologna detto Tuscolano</title>, <pubPlace>Bologna</pubPlace>
+         <date>1582</date>, in 8, M. 51. </bibl></item>
+   <item xml:id="c2d1e12946" n="4198" corresp="dcl:0ps">
+      <label>4198.</label>
+      <bibl><title>Les DÉLICES des Pays Bas ou déscription des XVII Provinces Belgiques</title>,
+            <pubPlace>Lieges</pubPlace><date> 1669</date>, in 12, volumi V, figurato. <note>Con
+            molte tavole de’ principali edifici di Fiandra, ma con scarsissime notizie per gli
+            oggetti d’arte, estendendosi l’opera molto sulle notizie storiche</note>. </bibl></item>
+   <item xml:id="c2d1e12958" n="4200">
+      <label>4200.</label>
+      <bibl><author>GUALDO Priorato Galeazzo</author>, <title>Relazione delle provincie unite del
+            Paese Basso</title>, <pubPlace>Colonia</pubPlace><date> 1668</date>, in 4 piccolo.
+            <note>Libro non comune e ben fatto di un autore distinto e meno conosciuto di quello che
+            merita</note>. </bibl></item>
+   <item xml:id="c2d1e13064" n="4214" corresp="dcl:6ck">
+      <label>4214.</label>
+      <bibl><author>MIGLIORE Ferdinando Leopoldo</author>, <title>Firenze, città nobilissima
+            illustrata</title>. Prima, seconda, e terza parte del primo libro,
+            <pubPlace>Firenze</pubPlace>
+         <date>1684</date>, in 4. <note>Quest’opera non venne mai proseguita più oltre, e sarebbe
+            stata della più grande utilità, poiché ben incominciata, e derivata dalle migliori
+            sorgenti.</note>
+      </bibl></item>
+   <item xml:id="c2d1e13133" n="4221" corresp="dcl:gc5">
+      <label>4221.</label>
+      <bibl><author>BEZZI Giuliano</author>, <title>Il fuoco trionfante: racconto della traslazione
+            della Madonna del Fuoco di Forlì, solennizzato nel 1636</title>, stampato in detta città
+         nel <date>1637</date>, in 4, fig.</bibl></item>
+   <item xml:id="c2d1e13364" n="4243">
+      <label>4243.</label>
+      <bibl><author>MORIGIA Paolo</author>, <title>Historia dell’antichità di Milano</title>, divisa
+         in quattro libri, <pubPlace>Venezia</pubPlace>, appresso <publisher>i Guerra</publisher>,
+            <date>1592</date>, in 4. <note>Esemplare con emende manoscritte del p. Allegranza.
+            Aggiuntavi <bibl><title>la nobiltà, e progenie dei signori sessanta del Consiglio
+                  Generale della città di Milano</title></bibl>. Tutte le opere di questo
+            raccoglitor diligente di patrie memorie sono da tenersi in pregio.</note>
+      </bibl></item>
+   <item xml:id="c2d1e13403" n="4249" corresp="dcl:vvp">
+      <label>4249.</label>
+      <bibl><title>OPICELLO Monumenta Bibliothecae Ambrosianae</title>,
+            <pubPlace>Mediolani</pubPlace>
+         <date>1618</date>, in 8. <date>Interessantissimo e raro libretto per la storia, e le
+            derivazioni delle preziosità ivi custodite, e pervenute.</date>
+      </bibl></item>
+   <item xml:id="c2d1e13428" n="4253" corresp="dcl:tzg">
+      <label>4253.</label>
+      <bibl><author>SORMANI Nicolò</author>, <title>Giornate de’ passeggi,
+            storico-topografico-critici nella città, e diocesi di Milano</title>,
+            <pubPlace>Milano</pubPlace>
+         <date>1751</date>, in 8. <note>Libro fatto più per gli ecclesiastici, che per gli amatori
+            degli studj, e delle antichità.</note>
+      </bibl></item>
+   <item xml:id="c2d1e13497" n="4260">
+      <label>4260.</label>
+      <bibl><author>MANNLICH</author>, <title>Notice des tableaux de la Galérie Royale de
+            Schlesheim</title>, <pubPlace>Munic</pubPlace>
+         <date>1810</date>, in 8. <note>Scritto in tedesco, ove sono molte notizie intorno le
+            antiche pitture di quella R. Galleria.</note></bibl></item>
+   <item xml:id="c2d1e13566" n="4268">
+      <label>4268.</label>
+      <bibl><author>PETRINI Paolo</author>, <title>Facciate delle chiese più cospicue di
+            Napoli</title>, tavole 20, in 4 obl., <pubPlace>Napoli</pubPlace>
+         <date>1718</date>. — Principali parti della città di Napoli, 21 vedute delle più belle
+         fabbriche, fortezze, e strade. Sono però 26 vedute. — Facciate delli palazzi più cospicui
+         della città di Napoli, tav. 16, legate in un sol volume. Opera di meno che mediocre
+         esecuzione, e poco conosciuta. <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+      </bibl></item>
+   <item xml:id="c2d1e13596" n="4272">
+      <label>4272.</label>
+      <bibl><author>VIVENZIO Nicola</author>, <title>Delle antiche provincie del Regno di Napoli da
+            Carlo I d’Angiò, fino al Re Cattolico Carlo III</title>, <pubPlace>Napoli</pubPlace>
+         <date>1811</date>, in 4.</bibl></item>
+   <item xml:id="c2d1e13652" n="4278">
+      <label>4278.</label>
+      <bibl><author>MOSCHINI Giovan Antonio</author>,<title> Breve guida all’amico delle belle arti
+            per la città di Padova</title>, <date>1817</date>, in 12. <note>Estratta dall’opera più
+            estesa pubblicata nello stesso anno dal medesimo autore.</note>
+      </bibl></item>
+   <item xml:id="c2d1e13710" n="4286" corresp="dcl:wjk">
+      <label>4286.</label>
+      <bibl><author>FELIBIEN</author>, <title>Recueil des déscriptions des peintures et autres
+            ouvrages faites pour le Roy</title>, <pubPlace>Paris</pubPlace>
+         <date>1682</date>, in 12, fig.</bibl>
+      <note>Libretto elegantissimo in mar. dor. ove sono due bei ritratti del re, e della regina.
+         Contiene le descrizioni delle 8 tappezzerie di le Brun, dell’Arco alla piazza del Delfino,
+         della famiglia di Dario dipinta per gabinetto reale, la descrizione delle feste, e della
+         villa di Versailles, e un romanzetto allegorico in fine intitolato Le songe de Philomathe
+         ec.</note>
+   </item>
+   <item xml:id="c2d1e13755" n="4293">
+      <label>4293.</label>
+      <bibl>
+         <title>NOTICES des desseins originaux, tableaux, statues et autres objets trasportes
+            d’Italie en France</title>, vol. 14, in 12. <note>In differenti epoche uscivano questi
+            piccoli volumetti a Parigi, secondo le varie esposizioni, e sono qui riuniti dal 1796 in
+            poi.</note></bibl></item>
+   <item xml:id="c2d1e14036" n="4324">
+      <label>4324.</label>
+      <bibl><author>SPRETI Desiderii ravennatis</author>, <title>De amplitudine, de vastatione, et
+            de instauratione urbis Ravennae</title>, <pubPlace>Venetiis</pubPlace>, per <fw
+            type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+         <publisher>Matheum Capcasam</publisher>, <date>1489</date>, in 8. <note>D’incontro al
+            titolo è una lettera di Giacomo Franco ravennate diretta a Niccolò Foscari patrizio
+            veneto. Lo Spreti <pb type="cico" n="284"/> poi con altra dedica intitola il suo libro a
+            Giovan Antonio Marcello patrizio veneto.</note>
+      </bibl></item>
+   <item xml:id="c2d1e14327" n="4348">
+      <label>4348.</label>
+      <bibl><author>BARDI Girolamo</author>, <title>Delle cose notabili della città di Venezia,
+            coll’aggiunta della dichiarazione delle storie dipinte nel Palazzo Ducale</title>,
+            <pubPlace>Venezia</pubPlace>, <publisher>Valgrisio</publisher>, <date>1587</date>, in 8.
+      </bibl></item>
+   <item xml:id="c2d1e14389" n="4357">
+      <label>4357.</label>
+      <bibl><author>CORONELLI P.</author>, <title>Procuratori di S. Marco ragguardevoli per lo <pb
+               type="cico" n="287"/>ro dignità e meriti, colla loro origine, e cronologia
+            descritti</title>, <pubPlace>Venezia</pubPlace>
+         <date>1705</date>, in 12. <note>Quaranta edizioni almeno si fecero della guida del
+            Coronelli in prova della povertà di critica in cui si trovava il mondo allora, e della
+            prevenzione che in favore di questo laboriosissimo frate esisteva, sebbene non avesse
+            ombra di gusto.</note>
+      </bibl></item>
+   <item xml:id="c2d1e14436" n="4364" corresp="dcl:xzf">
+      <label>4364.</label>
+      <bibl><author>FILOSI Giuseppe</author>, <title>Relazione istorica del campanile di S.
+            Marco</title>, <pubPlace>Venezia</pubPlace>
+         <date>1745</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e14467" n="4368">
+      <label>4368.</label>
+      <bibl><author>LOREDANO Francesco</author>, <title>Vita di Alessandro III Pontefice
+            Massimo</title>, <pubPlace>Venezia</pubPlace>, <date>1637</date>, per <publisher>il
+            Sarzina</publisher>, in 8. — Aggiuntavi: <title>La vittoria navale ottenuta dalla
+            Repubblica Veneziana contro Ottone figliuolo di Federico I Imperatore; e la restituzione
+            di Alessandro III venuto a Venezia, descritta da Girolamo Bardi fiorentino</title>,
+            <pubPlace>Venezia</pubPlace>, presso <publisher>Francesco Ziletti</publisher>,
+            <date>1585</date>. <note>Libri utilissimi per la spiegazione delle pitture riguardanti i
+            fasti patrj, che si vedono nel Palazzo Ducale di Venezia.</note>
+      </bibl></item>
+   <item xml:id="c2d1e14487" n="4371" corresp="dcl:9zq">
+      <label>4371.</label>
+      <bibl>
+         <title>MEMORIE intorno l’antichissima Scuola della Madonna de’ Mascoli, eretta nella ducale
+            basilica di S. Marco</title>, <pubPlace>Venezia</pubPlace>
+         <date>1778</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e14512" n="4375">
+      <label>4375.</label>
+      <bibl><author>MOSCHINI Giovan Antonio</author>, <title>Ragguaglio delle cose notabili nella
+            chiesa e nel seminario patriarcale di S. M. della Salute in Venezia</title>,
+            <date>1819</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e14557" n="4381" corresp="dcl:0kh dcl:gjz">
+      <label>4381.</label>
+      <bibl><title>TEATRO delle fabbriche più cospicue in prospettiva</title>, sì pubbliche, che
+         private della città di <pubPlace>Venezia</pubPlace>, per <publisher>Giovan Battista
+            Albrizzi</publisher>, in 4 oblongo. <note>Quest’operetta in 45 tavole compresa, una
+            bella pianta di Venezia in piccolo, è assai ben fatta: e molto preferibile a quella del
+            Formaleoni. Francesco Zucchi fu l’intagliatore.</note>
+      </bibl></item>
+   <item xml:id="c2d1e14694" n="4396">
+      <label>4396.</label>
+      <bibl><author>PEZZI Jean</author>, <title>Vienne, et ses environs precedée d’un precis
+            historique sur cette ville</title>, 4me edition revue et augmentée, <date>1818</date>,
+         in 16. <note>Questo libro è fatto secondo il bisogno de’ viaggiatori, ed è utile, conciso,
+            chiaro, sebbene le sue opinioni tendano a lodar tutto, per rendersi accetto, con poca
+            libertà ne’ suoi giudizj.</note></bibl></item>
+   <item xml:id="c2d1e14736" n="4399">
+      <label>4399.</label>
+      <bibl><author>LANDO Ortensio</author>, <title>Sette libri de’ cataloghi a varie cose
+            appartenenti non solo antiche, ma anche moderne, opera molto utile all’historia, et da
+            cui prender si può materia di favellare d’ogni proposito che ci occorra</title>,
+            <pubPlace>Vinegia</pubPlace>, presso <publisher>Gabriel Giolito</publisher>,
+            <date>1552</date>, in 8. <note>Libro di non comune interesse e ripieno di curiose
+            notizie. Questo è composto da Ortensio Lando; e parlando in alcuni di questi cataloghi
+            degli uomini a’ suoi tempi chiari per dottrina, non manca di parlar di se
+         stesso.</note></bibl></item>
+   <item xml:id="c2d1e14774" n="4401">
+      <label>4401.</label>
+      <bibl><author>De MAROLLES</author>, <title>Catalogue de livres d’estampes</title>,
+            <pubPlace>Paris</pubPlace>
+         <date>1672</date>, in 8. <note>Questi due cataloghi possono ritenersi tra i più rari e
+            preziosi in questo genere.</note></bibl></item>
+   <item xml:id="c2d1e15019" n="4419" corresp="dcl:gs5 dcl:x5g">
+      <label>4419.</label>
+      <bibl><author>HELLE et REMY</author>, <title>Catalogue d’une colléction de desseins, tableaux
+            et estampes du Cabinet de M. Manglard peintre</title>, <pubPlace>Paris</pubPlace>
+         <date>1762</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e15108" n="4429" corresp="dcl:c5z">
+      <label>4429.</label>
+      <bibl><author>REMY</author>, <title>Catalogue raisonné des curiosités du Cabinet de Mad.
+            Dubois Jourdain</title>, <pubPlace>Paris</pubPlace>
+         <date>1766</date>, avec prix. </bibl></item>
+   <item xml:id="c2d1e15222" n="4446">
+      <label>4446.</label>
+      <bibl><author>CHEREAU</author>,<title> Marchand d’estampes, catalogue des estampes provenantes
+            des fonds des plaches de Gerard d’Audran</title>, Poilly, Bernanrd, Lépicier,
+            <pubPlace>Paris</pubPlace>
+         <date>1770</date>, in 4. </bibl></item>
+   <item xml:id="c2d1e15323" n="4458" corresp="dcl:465">
+      <label>4458.</label>
+      <bibl><author>REMY</author>, <title>Catalogue des tableaux, bronzes, et marbres du Cabinet de
+            M. ***</title>, <pubPlace>Paris</pubPlace>
+         <date>1773</date>, in 8. <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+      </bibl></item>
+   <item xml:id="c2d1e15335" n="4459">
+      <label>4459.</label>
+      <bibl><author>REMY</author>, <title>Catalogue d’une parfaite colléction de tableaux de maitres
+            renommés la plupart hollandois, ou flamands</title>, <pubPlace>Paris</pubPlace>
+         <date>1773</date>, in 12, coi prezzi.</bibl></item>
+   <item xml:id="c2d1e15489" n="4475">
+      <label>4475.</label>
+      <bibl><title>CATALOGUE des tableaux et desseins du Cabinet de M. Caron</title>,
+            <pubPlace>Paris</pubPlace>
+         <date>1779</date>, en 12. </bibl></item>
+   <item xml:id="c2d1e15558" n="4482" corresp="dcl:bgw">
+      <label>4482.</label>
+      <bibl><author>BASAN</author>, <title>Catalogue des tableaux, desseins, estampes des plus
+            grands maîtres, provenant du Cabinet de M ***</title>, <pubPlace>Paris</pubPlace>
+         <date>1781</date>, in 8, con prezzi. </bibl></item>
+   <item xml:id="c2d1e15643" n="4494">
+      <label>4494.</label>
+      <bibl><author>JULLIOT, et Paillet</author>, <title>Catalogue des vases, colonnes, tables,
+            marbres du Cabinet du Duc d’Aumont</title>, <pubPlace>Paris</pubPlace>
+         <date>1782</date>, in 8, avec 32 planches, avec prix.</bibl></item>
+   <item xml:id="c2d1e15676" n="4497">
+      <label>4497.</label>
+      <bibl><title>CATALOGUE des tableaux de differentes écoles, gouaches, dessins, etc.</title>,
+            <pubPlace>Paris</pubPlace>
+         <date>1783</date>. </bibl></item>
+   <item xml:id="c2d1e15847" n="4519">
+      <label>4519.</label>
+      <bibl><author>Le BRUN</author>, <title>Catalogue d’une belle colléction de tableaux du Cabinet
+            de M. ***</title>, <pubPlace>Paris</pubPlace>
+         <date>1786</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e15853" n="4520">
+      <label>4520.</label>
+      <bibl><author>FOLLIOT de la Lande et Julliot fils</author>, <title>Catalogue des tableaux,
+            desseins, estampes du Cabinet de M. Baudoin</title>, <pubPlace>Paris</pubPlace>
+         <date>1786</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e15932" n="4531">
+      <label>4531.</label>
+      <bibl><author>Le BRUN</author>, <title>Catalogue d’une très belle colléction de tableaux
+            d’Italie, Flandre, Hollande et France, vases, marbres, bronzes etc. du Cabinet de M. de
+            Vendreuil</title>, <pubPlace>Paris</pubPlace>
+         <date>1787</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e15939" n="4532" corresp="dcl:m2n">
+      <label>4532.</label>
+      <bibl><author>Le BRUN</author>, <title>Catalogue des tableaux capiteaux, et objets rares et
+            curieux du Cabinet de M. le Chev. Lambert, et de <fw type="foot"/>
+            <pb type="memofonte"/>
+            <fw type="head"/> M. de Porel</title>, <pubPlace>Paris</pubPlace>
+         <date>1787</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e15951" n="4533">
+      <label>4533.</label>
+      <bibl><title>CATALOGUE d’un excellent et precieux Cabinet de Desseins: provenants du Cabinet
+            de M. John Bernard, dans la vente faite en <date>1787</date></title>,
+            <pubPlace>Londres</pubPlace>, in 8. </bibl></item>
+   <item xml:id="c2d1e15969" n="4536">
+      <label>4536.</label>
+      <bibl><author>PAILLET</author>, <title>Catalogue d’une collection précieuse de tableaux des
+            trois écoles, et autres objéts etc.</title>, <pubPlace>Paris</pubPlace>
+         <date>1787</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e15990" n="4538">
+      <label>4538.</label>
+      <bibl><author>BARTSCH Adam</author>, <title>Catalogue raisonné de toutes les estampes, qui
+            forment l’oeuvre de Lucas de Leyde</title>, <pubPlace>Vienne</pubPlace>
+         <date>1788</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e16194" n="4558">
+      <label>4558.</label>
+      <bibl><title>CATALOGO de’ capi d’opera di pittura, scultura, architettura etc. ed altre
+            curiosità trasportate dall’Italia in Francia</title>, <pubPlace>Venezia</pubPlace><date>
+            1799</date>, in 4, edizione seconda, M. 93.</bibl></item>
+   <item xml:id="c2d1e16329" n="4570">
+      <label>4570.</label>
+      <bibl><title>CATALOGUE de l’oeuvre d’Albert Durer par un amateur</title>,
+            <pubPlace>Dessau</pubPlace><date> 1805</date>, in 12. </bibl></item>
+   <item xml:id="c2d1e16407" n="4578" corresp="dcl:d2x">
+      <label>4578.</label>
+      <bibl><title>CATALOGUE d’une belle colléction de tableaux de diverses écoles</title>,
+            <date>1808</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e16455" n="4583">
+      <label>4583.</label>
+      <bibl><title>CATALOGUE des livres rares, et précieux de la Biblioteque de M.***</title>,
+            <pubPlace>Paris</pubPlace><date> 1811</date>, in 8.</bibl></item>
+   <item xml:id="c2d1e16485" n="4585">
+      <label>4585.</label>
+      <bibl><title>CATALOGUE of that distinguished and celebrated library</title>,
+            <pubPlace>London</pubPlace><date> 1819</date>, in 4. <note>Questo è il catalogo, che
+            servì alla vendita dei libri rari del duca di Malborough coi prezzi segnati a mano da
+            noi stessi</note>.</bibl></item>
+   <item xml:id="c2d1e16534" n="4590">
+      <label>4590.</label>
+      <bibl><title>CATALOGUE d’une colléction d’estampes choisies, etc. après la décès du feu Jean
+            Casanova dirécteur de l’Académie de Dresde</title>, in 12. </bibl></item>
+   <item xml:id="c2d1e16553" n="4593" corresp="dcl:h8n">
+      <label>4593.</label>
+      <bibl><title>NOTICE de quelques tableaux précieux après le décès de M. de Pillon</title>,
+            <pubPlace>Paris</pubPlace>, in 8. </bibl></item>
+   <item xml:id="c2d1e16559" n="4594" corresp="dcl:v2q">
+      <label>4594.</label>
+      <bibl><title>NOTICE de quelques bons tableaux de différents maîtres du Cabinet de M.
+            ***</title>, <pubPlace>Paris</pubPlace>, in 8.</bibl></item>
+   <item xml:id="c2d1e16619" n="4601">
+      <label>4601.</label>
+      <bibl><author>FABRICY Gabriel le R. Pere</author>, <title>Récherches sur l’époque de
+            l’équitation</title>. <note>Vedi fra i Costumi</note>. </bibl></item>
+   <item xml:id="c2d1e16684" n="4611">
+      <label>4611.</label>
+      <bibl><title>LIBRO di arnesi, ed ornamenti per cavalli, e carrozze, incisi in rame con
+            diligenza, ed eleganza, e i respettivi prezzi di ciascheduno in lingua inglese, tedesca,
+            spagnuola, e italiana</title>. <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+         <note>Con cinque figure di cavalli guarniti: sono in tutto 34 grandi tavole in foglio
+            piegate in quarto</note>. </bibl></item>
+   <item xml:id="c2d1e16715" n="4615">
+      <label>4615.</label>
+      <bibl><author>PALMIERI di Lorenzo</author>, <title>Perfette regole, e modi di
+            cavalcare</title>, <pubPlace>Venezia</pubPlace>
+         <date>1625</date>, in 4, fig. <note>Il frontespizio figurato in rame porta la data
+            dell’anno dopo. L’opera non è molto estesa, e contiene al fine un ristretto delle
+            infermità de’ cavalli con una tavola intagliata in rame.</note>
+      </bibl></item>
+   <item xml:id="c2d1e16785" n="4625" corresp="dcl:9cm">
+      <label>4625.</label>
+      <bibl><author>TEMPESTA Antonio</author>,<title> Sedici cavalli in varie mosse incisi da
+            Giuseppe Rossi vicentino in 8</title>. <note>Questo mediocre artista non poteva imitare
+            la maestria degli originali.</note>
+      </bibl></item>
+   <item xml:id="c2d1e16791" n="4626">
+      <label>4626.</label>
+      <bibl><title>TRAITÉ des voitures pour servir de supplément au nouveau parfait maréchal, avec
+            la construction d’une Berline nouvelle, nommée l’inversable</title>,
+            <pubPlace>Paris</pubPlace>
+         <date>1756</date>, in 4. <note>Con 16 tavole intagliate in rame.</note>
+      </bibl></item>
+   <item xml:id="c2d1e16797" n="4627">
+      <label>4627.</label>
+      <bibl><author>VERNET Carlo</author>, <title>e Orazio figlio</title>. <note>Raccolta fatta da
+            noi di 72 tavole di cavalli diversi, parte intagliati in rame, e parte in litografia.
+            Incominciando dalle parti elementari della testa del cavallo in grande, offrono la più
+            bella serie che sia mai stata disegnata de’ studj per l’intelligenza delle parti, e del
+            movimento di questo nobilissimo animale. Prove scelte, delle quali 32 tavole sono in
+            gran quarto, e 40 in foglio atlantico.</note>
+         <pb type="cico" n="314"/>
+      </bibl></item>
+   <item xml:id="c2d1e16826" n="4630">
+      <label>4630.</label>
+      <bibl><author>AMES</author>, <title>Typographical antiquities</title>. Vedi <ref>Dibdin</ref>.
+      </bibl></item>
+   <item xml:id="c2d1e16844" n="4633">
+      <label>4633.</label>
+      <bibl>
+         <title>BIBLIOTHECA Excc. D. Nicolai Josephi de Azzara, ordine alfabetico descripta</title>,
+            <pubPlace>Romae</pubPlace>
+         <date>1806</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e16850" n="4634">
+      <label>4634.</label>
+      <bibl>
+         <title>BIBLIOTHECA Stoschiana, seu catalogus selectissimorum librorum quos collegerat
+            Philippus Liber Baro de Stosch</title>, <pubPlace>Florentiae</pubPlace>
+         <date>1759</date>, in 8. <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+      </bibl></item>
+   <item xml:id="c2d1e16869" n="4636">
+      <label>4636.</label>
+      <bibl><author>BONICELLI Joannis</author>, <title>Bibliotheca Pisanorum Veneta, adnotationibus
+            nonnullis illustrata</title>, tomi 3, <pubPlace>Venetiis</pubPlace>
+         <date>1807</date>, in 5. </bibl></item>
+   <item xml:id="c2d1e16875" n="4637">
+      <label>4637.</label>
+      <bibl><author>BRAVETTI Jacopo</author>, <title>Indice dei libri a stampa citati per testo di
+            lingua nel Vocabolario della Crusca</title>, <pubPlace>Verona</pubPlace>
+         <date>1798</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e16902" n="4641">
+      <label>4641.</label>
+      <bibl><author>BURE (de) Guillaume</author>, <title>Tome huitieme contenant une table destinée
+            a facilitér les recherches des livres anonimes</title>, <pubPlace>Paris</pubPlace>
+         <date>1793</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e16914" n="4643">
+      <label>4643.</label>
+      <bibl><author>BURE (de) Guillaume</author>, <title>Catalogue des livres rares de M. de
+            Limare</title>, <pubPlace>Paris</pubPlace>
+         <date>1786</date>, in 8, coi prezzi. </bibl></item>
+   <item xml:id="c2d1e16939" n="4647">
+      <label>4647.</label>
+      <bibl><author>CLARK</author>, <title>Repertorium bibliographicum</title>,
+            <pubPlace>London</pubPlace>
+         <date>1819</date>, vol. 2, in 4. <note>Opera superficiale, ove si tratta di alcuni preziosi
+            libri posseduti da diversi amatori di curiosità in Inghilterra, e ricco di molti bei
+            ritratti intagliati in rame.</note>
+      </bibl></item>
+   <item xml:id="c2d1e16951" n="4649">
+      <label>4649.</label>
+      <bibl><author>DIBDIN Thomas</author>, <title>Typographical antiquities, or the history of
+            printing in England, Scotland, and Ireland, containing memoirs of our ancient printers,
+            and a register of the books printed by the late Joseph Ames, considerably augmented by
+               <pb type="cico" n="316"/> William Herbert; and now great by en larged, with copious
+            notes, and illustrated with appropriate engravings: comprehending the history of English
+            literature, and a viw of the progress of the art of engraving in Great Britain</title>,
+            <pubPlace>London</pubPlace>
+         <date>1810 a 1816</date>, vol. 4, in 4, fig. <note>Posseggonsi da noi già quattro volumi di
+            quest’opera ricchissima di cognizioni per la bibliografia e tipografia inglese: eseguita
+            con tutto il lusso, e l’eleganza, adornata di tutte le erudizioni utili, e inutili.
+            Accreditato il dotto bibliografo per la magnifica opera della Spenceriana, si è messo a
+            produrre in simil forma i suoi libri, che a misura del gusto, e della ricchezza inglese
+            arricchisce di quantità di stampe in legno, in rame, a fumo, di caratteri variati, di
+            monumenti, e di ritratti che fanno ascendere tropp’alto il prezzo di queste opere, e le
+            confinano nelle biblioteche dei ricchi, quasi impossibilitandone l’acquisto agli
+            studiosi.</note>
+      </bibl></item>
+   <item xml:id="c2d1e16971" n="4651">
+      <label>4651.</label>
+      <bibl>
+         <title>DICTIONAIRE bibliographique, historique, et critique des livres rares, qui n’ont
+            aucun prix fixe tant que des autres connus etc.</title>, <pubPlace>Paris</pubPlace>
+         <date>1790</date>, vol. 4, in 8. </bibl></item>
+   <item xml:id="c2d1e16990" n="4654">
+      <label>4654.</label>
+      <bibl><author>FONTANINI Giusto</author>,<title> Biblioteca dell’eloquenza italiana, colle
+            annotazioni di Apostolo Zeno, accresciuta di nuove aggiunte</title>,
+            <pubPlace>Parma</pubPlace>
+         <date>1802</date>, vol. 2. <note>Questa è la più copiosa e ricca edizione dell’opera del
+            Fontanini preceduta di una dotta prefazione del Forcellini, e seguita da preziose note
+            addizionali a quella del Zeno di un anonimo che da noi si tace per rispettare la sua
+            modestia, così da lui essendo desiderato.</note>
+         <pb type="cico" n="317"/>
+      </bibl></item>
+   <item xml:id="c2d1e16998" n="4655">
+      <label>4655.</label>
+      <bibl><author>GAMBA Bartolommeo</author>, <title>Serie delle edizioni de’ testi di lingua
+            italiana, vol. 2</title>, <pubPlace/>Milano <date>1812</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e17004" n="4656">
+      <label>4656.</label>
+      <bibl><author>LUCA (de) D. Tommaso</author>, <title>Catalogo d’una pregievole collezione di
+            manoscritti, e di libri a stampa delle più ricercate edizioni</title>,
+            <pubPlace>Venezia</pubPlace>
+         <date>1816</date>, in 4. </bibl></item>
+   <item xml:id="c2d1e17010" n="4657">
+      <label>4657</label>. <bibl><author>MARTINIERE (de la)</author>, <title>Conseil pour former une
+            bibliotheque peu nombreuse, mais choisie</title>, <pubPlace>Berlin</pubPlace>
+         <date>1756</date>, in 8.</bibl></item>
+   <item xml:id="c2d1e17023" n="4659">
+      <label>4659.</label>
+      <bibl><author>MORELLI Jacopo</author>, <title>Bibliotheca Maffei Pinelli veneti descripta et
+            adnotationibus illustrata</title>, <pubPlace>Venetiis</pubPlace>
+         <date>1787</date>, vol. 7, in 8.</bibl></item>
+   <item xml:id="c2d1e17035" n="4661" corresp="dcl:vvp">
+      <label>4661.</label>
+      <bibl><author>OPICELLO Jacobi Philippi</author>, <title>Monumenta Bibliothecae
+            Ambrosianae</title>, <pubPlace>Mediolani</pubPlace>
+         <date>1618</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e17047" n="4663">
+      <label>4663.</label>
+      <bibl><author>PEIGNOT Gabriel</author>, <title>Dictionnaire raisonné de la
+         Bibliologie</title>, <pubPlace>Paris</pubPlace>
+         <date>1802</date>, 3 vol., in 8. </bibl></item>
+   <item xml:id="c2d1e17066" n="4666" corresp="dcl:kzq">
+      <label>4666.</label>
+      <bibl><author>VERNAZZA Bar.</author>, <title>Osservazioni tipografiche sopra i libri impressi
+            in Piemonte nel XV secolo</title>, <pubPlace>Bassano</pubPlace>
+         <date>1807</date>, in 8, M. 54. </bibl></item>
+   <item xml:id="c2d1e17101" n="4669">
+      <label>4669.</label>
+      <bibl><author>ANCARANO Gasparo</author>, <title>Novo rosario della gloriosissima Vergine
+            Maria</title>. Aggiuntivi in fine i miracoli, <pubPlace>Venezia</pubPlace>, per
+            <publisher>Bernardo Giunti</publisher>, <date>1588 e 1587</date>, in 4, fig.
+            <note>Sonovi 20 tavole intagliate in rame, compresi i frontespizj intagliate da Giacomo
+            Franco e 15 sonetti in esposizione de’ 15 Paternoster, 150 ottave per le 150 Ave Marie,
+            e un orticello spirituale. Libretto graziosamente intagliato e nitidamente
+            stampato.</note>
+      </bibl></item>
+   <item xml:id="c2d1e17134" n="4674" corresp="dcl:fgh">
+      <label>4674.</label>
+      <bibl><author>BANNIER l’abbé</author>, <title>La Mythologie, et les fables expliquées par
+            l’histoire</title>, vol. 3, in 4, <pubPlace>Paris</pubPlace>
+         <date>1738</date>. <note>Opera assai pregiata per le sue note erudite.</note>
+      </bibl></item>
+   <item xml:id="c2d1e17152" n="4677" corresp="dcl:c07">
+      <label>4677.</label>
+      <bibl><author>De BENSERADE M.</author>, <title>Metamorfoses d’Ovide en Rondeaux imprimés et
+            enrichis de figures par ordre de S. Majesté</title>, vol. 2, in 12,
+            <pubPlace>Amsterdam</pubPlace>
+         <date>1714</date>. <note>Operetta di poco merito, apparsa e sostenuta dal Mecenate che ne
+            favorì la spesa, e assistita da Le Brun, che disegnò certamente alcune delle tante
+            tavole, di cui sono composti i due volumi.</note>
+      </bibl></item>
+   <item xml:id="c2d1e17222" n="4687">
+      <label>4687.</label>
+      <bibl><author>CHARTARIO Vincentio</author>, <title>Imagines Deorum latino sermone expressae ab
+            Antonio Verderio</title>, <pubPlace>Lugduni</pubPlace>
+         <date>1581</date>, in 4, fig. <note>Con singolari e non spregievoli tavole in legno.</note>
+      </bibl></item>
+   <item xml:id="c2d1e17285" n="4696">
+      <label>4696.</label>
+      <bibl><author>COMITIS Natalis</author>, <title>Mythologiae sive explicationis fabularum libri
+            decem.</title> — Accedunt Linocerii Musarum Mythologia, et alia Antonii Tritonii
+         Utinensis, <pubPlace>Patavii</pubPlace>
+         <date>1637</date>, in 4, figurato. </bibl></item>
+   <item xml:id="c2d1e17306" n="4699">
+      <label>4699.</label>
+      <bibl><author>DOLCE</author>, <title>Le trasformazioni tratte da Ovidio</title>,
+            <pubPlace>Venezia</pubPlace>, <publisher>Sansovino</publisher>, <date>1568</date>, in 4.
+            <note>Edizione di qualche pregio, ad ogni canto della quale sono le tavole in legno di
+            mediocre intaglio.</note>
+      </bibl></item>
+   <item xml:id="c2d1e17318" n="4701">
+      <label>4701.</label>
+      <bibl><author>DUPUIS</author>, <title>Origine de tous les cultes, ou religion
+            universelle</title>, vol. 3, in 4, avec un atlas, <pubPlace>Paris</pubPlace>
+         <date>an. troisième de la République.</date>
+         <note>Opera profondissima, e dedicata alla moglie dell’autore per aver salvato ella stessa
+            il manoscritto che egli voleva consegnare alle fiamme, irritato di sdegno (come egli
+            dice) contro la indiscrezione di alcuni letterati, che perseguitavano chi rischiarar
+            voleva coi lumi il proprio secolo.</note>
+      </bibl></item>
+   <item xml:id="c2d1e17415" n="4715">
+      <label>4715.</label>
+      <bibl><author>HENSBERGIO Vincentio</author>, <title>Viridarium Marianum variis rosariorum etc.
+            etc.</title>, <pubPlace>Antuerpiae</pubPlace>
+         <date>1626</date>, in 8, figurato. <note>Sonovi poche tavole in rame mediocri, e sparse fra
+            il testo del volume.</note>
+      </bibl></item>
+   <item xml:id="c2d1e17427" n="4717">
+      <label>4717.</label>
+      <bibl><author>LEONISSA Giovan Francesco</author>, <title>Conformità delle ceremonie cinesi
+            all’idolatria greca e romana</title>, <pubPlace>Colonia</pubPlace>
+         <date>1701</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e17523" n="4731" corresp="dcl:jp6">
+      <label>4731.</label>
+      <bibl><author>De MOUSTIER</author>, <title>Lettres à Emilie sur la mythologie</title>, vol. 4,
+         fig., a <pubPlace>Buckingham</pubPlace>
+         <date>1792</date>, in 8, fig. <note>Opera che rese aggradevoli e facili le cognizioni
+            mitologiche nell’istruzione della gioventù.</note>
+      </bibl></item>
+   <item xml:id="c2d1e17556" n="4735">
+      <label>4735.</label>
+      <bibl><author>PALEOTTI cardinale e vescovo di Bologna</author>, La stessa opera tradotta in
+         latino, <pubPlace>Ingolstadii</pubPlace>
+         <date>1594</date>, in 4. <note>In fine dell’edizione originale è indicato che gli altri tre
+            libri si daranno poi fuori a suo tempo, quantunque si pubblichi in questo volume non
+            tanto nell’italiano, che nella versione latina l’indice dei capitoli di quei libri che
+            non vennero poi mai pubblicati. Opera di un teologo rigorista.</note>
+      </bibl></item>
+   <item xml:id="c2d1e17568" n="4737" corresp="dcl:d00">
+      <label>4737.</label>
+      <bibl><author>PERNETTY Antoine Joseph</author>, <title>Les fables egyptiennes, et grécques
+            dévoilées et reduites au même principe avec une explication des hieroglyphes, et de la
+            guerre de Troye</title>, <pubPlace>Paris</pubPlace>
+         <date>1658</date>, in 8, vol. 2. </bibl></item>
+   <item xml:id="c2d1e17601" n="4742">
+      <label>4742.</label>
+      <bibl><title>RITI e costumi degli ebrei confutati dal dottor Paolo Medici coll’aggiunta d’una
+            lettera di Nicolò Stratta già rabbino ec.</title>, <pubPlace>Venezia</pubPlace>
+         <date>1788</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e17607" n="4743">
+      <label>4743.</label>
+      <bibl><title>RITRATTO totalmente simile della S. Nunziata di Firenze, donato dal G. D.
+            Francesco de’ Medici a S. Carlo l’anno 1580 ec.</title>, <pubPlace>Milano</pubPlace>
+         <date>1648</date>, in 8. <note>Libercolo di 31 pagine con un intaglio in legno nel
+            frontespizio.</note>
+      </bibl></item>
+   <item xml:id="c2d1e17613" n="4744">
+      <label>4744.</label>
+      <bibl><title>RITUUM ecclesiasticorum, sive sacrarum ceremoniarum S. R. Ecclesiae libri tres
+            non antea impressi</title>. Editi ab Antonio, et Silvano Cappellis civibus venetis,
+            <pubPlace>Venetiis</pubPlace>, <date>1516</date>, in fol., fig., impressum a
+            <publisher>Gregorio de Gregoriis</publisher>. </bibl></item>
+   <item xml:id="c2d1e17683" n="4754">
+      <label>4754.</label>
+      <bibl><author>VARO fra Francesco</author>, <title>Estratto del trattato circa il <pb
+               type="cico" n="328"/> culto, offerte, riti, e ceremonie che praticano i chinesi
+            ec.</title>, in <pubPlace>Colonia</pubPlace>
+         <date>1700</date>, in 12. </bibl></item>
+   <item xml:id="c2d1e17710" n="4758" corresp="dcl:hvs">
+      <label>4758.</label>
+      <bibl><author>WARBURTON</author>, <title>Dissertazione sulla iniziazione a’ misteri eleusini,
+            ovvero nuova spiegazione del libro VI di Virgilio ec.</title>,
+            <pubPlace>Venezia</pubPlace>
+         <date>1793</date>, in 8, M. 67. <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+      </bibl></item>
+   <item xml:id="c2d1e17757" n="4763">
+      <label>4763.</label>
+      <bibl><author>BUSCHING Giovan Gustavo</author>, <title>Dissertazione intorno una statuetta
+            antica rappresentante l’idolo Tyr</title>, <pubPlace>Breslavia</pubPlace>
+         <date>1819</date>, in 8, con una tavola in rame in lingua tedesca. </bibl></item>
+   <item xml:id="c2d1e17776" n="4766">
+      <label>4766.</label>
+      <bibl><author>CIAMPI Sebastiano</author>, <title>Feriae Varsavienses</title>,
+            <pubPlace>Varsaviae</pubPlace>
+         <date>1819</date>, in 4. <note>Trattasi particolarmente in questo quaderno d’illustrare
+            qualche luogo di Pausania, ed in ispecie del tempio di Giove Olimpico, con una tavola in
+            fol.</note>
+      </bibl></item>
+   <item xml:id="c2d1e17788" n="4768">
+      <label>4768.</label>
+      <bibl><author>CORDERO Sanquintino Giulio</author>, <title>Delle misure luc <pb type="cico"
+               n="330"/> chesi, e del miglior modo di ordinarle, lezione accademica</title>,
+            <pubPlace>Badia Fiesolana</pubPlace>
+         <date>1821</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e17802" n="4770">
+      <label>4770.</label>
+      <bibl><author>CUNNINGHAM Francis</author>, <title>Notes récuillies en visitant les prisons de
+            la Suisse, et rémarques sur les moyens de les améliorer</title>,
+            <pubPlace>Geneve</pubPlace>
+         <date>1820</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e17809" n="4771" corresp="dcl:5gx">
+      <label>4771.</label>
+      <bibl><title>DESCRIPTION, an improved history and description of the Tower of London</title>,
+            <pubPlace>London</pubPlace>
+         <date>1819</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e17821" n="4773">
+      <label>4773.</label>
+      <bibl><title>DESCRIPTION nouvelle de Blencheim, chateau de sa grandeur le Duc de
+            Malborough</title>, <pubPlace>Oxford</pubPlace>
+         <date>1815</date>, in 12. <fw type="foot"/>
+         <pb type="memofonte"/>
+         <fw type="head"/>
+         <note>Con alcune tavole in rame.</note>
+      </bibl></item>
+   <item xml:id="c2d1e17845" n="4776" corresp="dcl:c5h">
+      <label>4776.</label>
+      <bibl><title>DISCORSO letto nella grande aula dell’I. R. Palazzo delle Scienze ed Arti in
+            occasione della distribuzione de’ premj nell’I. R. Accademia delle Belle Arti l’anno
+               <date>1820</date></title>, in <pubPlace>Milano</pubPlace>, in 8. <note>Questo è un
+            discorso teorico del signor Fumagalli segretario di quell’Accademia.</note>
+         <pb type="cico" n="331"/>
+      </bibl></item>
+   <item xml:id="c2d1e17854" n="4777">
+      <label>4777.</label>
+      <bibl><title>The EXHIBITION of the Royal Accademy 1819 the fifty first</title>,
+            <pubPlace>London</pubPlace>, in 4. Unitovi <publisher>British Institution for promoting
+            the fine arts in the kingdom</publisher>, <pubPlace>London</pubPlace>
+         <date>1819</date>, in 4. </bibl></item>
+   <item xml:id="c2d1e17860" n="4778">
+      <label>4778.</label>
+      <bibl><author>FRANCESCHI Giacomo</author>, <title>Igéa de’ Bagni, e più particolarmente di
+            quelli di Lucca, edizione seconda</title>, <pubPlace>Lucca</pubPlace>
+         <date>1820</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e17872" n="4780">
+      <label>4780.</label>
+      <bibl><author>GRAZIADEI Ercole</author>, <title>Discorso sopra lo studio dell’ornato</title>,
+            <pubPlace>Ferrara</pubPlace> 6 aprile <date>1820</date>. <note>Seguito da altro discorso
+            sopra la vita di Benvenuto Tisi da Garofolo, stesso luogo ed anno. Il primo specialmente
+            di questi discorsi è pieno di bellissime idee.</note>
+      </bibl></item>
+   <item xml:id="c2d1e17878" n="4781">
+      <label>4781.</label>
+      <bibl><author>GUATTANI Antonio</author>, <title>Spiegazione di un basso rilievo denominato i
+            Fanti scritti di Carrara</title>, <pubPlace>Roma</pubPlace>
+         <date>1819</date>, in 4. <note>Con due tavole e il frontespizio figurato.</note>
+      </bibl></item>
+   <item xml:id="c2d1e17891" n="4783">
+      <label>4783.</label>
+      <bibl><author>HAYDON B. R. pittore inglese</author>, <title>Comparaison entre la tête d’un des
+            chévaux de Venise qui etoient sur l’arc triomphale des Thuilléries, et qu’on dit etre de
+            Lysippe, et la tête du cheval d’Elgin du Parthénon</title>, <pubPlace>Londres</pubPlace>
+         <date>1818</date>, in 8. <note>Con una tavola vivacemente intagliata. Sono asserite in
+            questa memoria alcune cose, che non sembrano fondate, intorno i cavalli di
+            Venezia.</note>
+      </bibl></item>
+   <item xml:id="c2d1e17897" n="4784">
+      <label>4784.</label>
+      <bibl><author>HAYDON B. R. pittore inglese</author>, <title>Erreur de Visconti relative à
+            l’action de la statue de l’Ilissus, dans la colléction d’Elgin au Museum
+            Britannique</title>, <pubPlace>Lond.</pubPlace>
+         <date>1819</date>, in 8, con una tavola. </bibl></item>
+   <item xml:id="c2d1e17929" n="4788">
+      <label>4788.</label>
+      <bibl><author>INGHIRAMI Francesco</author>, <title>Alcune figuline di Arezzo esposte</title>,
+            <pubPlace>Badia Fiesolana</pubPlace>
+         <date>1820</date>, in 4, fig. <note>Con 4 tavole in rame colorate. Undici copie soltanto
+            vennero stampate di questo opuscolo estratto dalla grand’opera di questo autore come
+            leggesi nella pagina a retro del frontespizio, ove è indicato il nome dei personaggi cui
+            furono destinate.</note>
+      </bibl></item>
+   <item xml:id="c2d1e17942" n="4790">
+      <label>4790.</label>
+      <bibl><author>Da PERSICO Giovan Battista</author>, <title>Anfiteatro di Verona e suoi nuovi
+            scavi descritti</title>, <pubPlace>Verona</pubPlace>
+         <date>1820</date>, in 8, fig. <note>Con tre tavole e il frontespizio figurato. In questo
+            insigne anfiteatro continuano le operazioni dirette a restituirlo al suo pristino
+            splendore per cura dell’autore, attuale podestà di Verona, il qual sta pubblicnado in
+            due volumi una guida ragionata pel forestiere onde possa ammirare le curiosità della sua
+            patria.</note>
+      </bibl></item>
+   <item xml:id="c2d1e17948" n="4791" corresp="dcl:zvj">
+      <label>4791.</label>
+      <bibl><author>PETRARCA</author>, <title>Le Rime</title>, <pubPlace>Padova</pubPlace>, nella
+            <publisher>tipografia del Seminario</publisher>, <date>1819 e 1820</date>, vol. 2, in 4
+         gr., fig. <note>L’edizione splendida di questo Canzoniere fu fatta per cura del signor
+            abate Antonio Marsan professore nell’Università di Padova. L’opera è ornata di molti
+            accuratissimi intagli, fra’ quali si distinguono due ritratti, l’uno del Petrarca,
+            l’altro di Laura, preso da un creduto originale di Simone Memmi, oltre i quali sono
+            sette vedute di luoghi relativi al Poeta intagliate da’ buoni maestri. La vita del Poeta
+            estesa con finezza di accorgimento, come se egli stesso parlasse, le nozioni amplissime
+            sparse nel volume, le cognizioni bibliografiche delle edizioni di Petrarca, e il lusso
+            elegante di quest’opera, assicurano all’egregio illustratore ed editore la riconoscenza
+            della posterità.</note>
+      </bibl></item>
+   <item xml:id="c2d1e17962" n="4793">
+      <label>4793.</label>
+      <bibl><title>STATUTI due suntuarii circa il vestire degli uomini e delle donne ordinati prima
+            dell’anno 1322 dal comune di Perugia</title>, tratti da un testo inedito,
+            <pubPlace>Perugia</pubPlace>
+         <date>1821</date>, in 4. </bibl></item>
+   <item xml:id="c2d1e17975" n="4795">
+      <label>4795.</label>
+      <bibl><author>STUKELEY D.</author>, <title>Paleografia britannica or discourses on antiquities
+            in Britain in which is given a particular account of Lady Roisia (foundress of Royston)
+            and her family witch a description of her cave there discovered in 1742</title>,
+            <pubPlace>Cambridge</pubPlace>
+         <date>1795</date>, in 8. </bibl></item>
+   <item xml:id="c2d1e17987" n="4797">
+      <label>4797.</label>
+      <bibl><author>VERMIGLIOLI Giovan Battista</author>, <title>Elogio d’Ignazio Danti
+            perugino</title>, <pubPlace>Perugia</pubPlace>
+         <date>1820</date>, in 4. </bibl></item>
+   <item xml:id="c2d1e17999" n="4799">
+      <label>4799.</label>
+      <bibl><title>La VILLA Sampieri in Casalecchio, sonetti epitalamici</title>,
+            <pubPlace>Bologna</pubPlace>
+         <date>1818</date>, in 4. <note>Scrissero uomini chiarissimi per trattare delle varie e
+            belle invenzioni che decorano questa villa, da noi riputata una delle più graziose
+            d’Italia, che nel suo nascere promette per cura del suo possessore d’abbellirsi ancor
+            maggiormente.</note>
+      </bibl></item>
+</tei:list>

--- a/bin/forensics/catalogo_to_json.rb
+++ b/bin/forensics/catalogo_to_json.rb
@@ -5,7 +5,7 @@ require "nokogiri"
 require "logger"
 
 
-basedir = "#{File.dirname(__FILE__)}/.."
+basedir = "#{File.dirname(__FILE__)}/../.."
 
 logger = Logger.new(STDOUT)
 

--- a/bin/forensics/investigation.xq
+++ b/bin/forensics/investigation.xq
@@ -1,34 +1,43 @@
 xquery version "3.0" encoding "UTF-8";
 
+(:~
+ : This query compares the TEI-encoded edition of Cicognara's
+ : Catalogo with the TEI encoding of the Getty records and returns
+ : a list of all the Catalogo items that do not have a corresponding
+ : record in the Getty.  It compares the cico number
+ :)
+
 declare namespace tei="http://www.tei-c.org/ns/1.0";
 declare namespace dc = "http://purl.org/dc/elements/1.1/";
 declare namespace dcterms="http://purl.org/dc/terms/";
 declare namespace gettyterms="http://portal.getty.edu/terms/gri/";
 
+
+(:
+ : Get the cico numbers from the Catalogo
+ :)
 let $items := doc("/db/apps/cicognara/data/catalogo.tei.xml")//tei:list[@type='catalog']/tei:item
 
 let $ciconums := for $i in $items return xs:string($i/@n)
 
+(:
+ : Get the cico numbers from the Getty records
+ :)
 let $getty_cicos := for $idno in collection("/db/apps/cicognara/data/getty_tei")//tei:idno[@type='cico']
 return xs:string($idno)
 
+
 (:
-for $item in $items
-let $cico := xs:string($item/@n)
-for $d in $getty_cicos[.= $cico]
-return $d
-:)
-
-(:let $items := subsequence($items, 1, 50) :)
-
-
+ : Select the Catalogo items whose cico number is not
+ : in the list of Getty cico numbers.
+ :)
 let $bads :=
-for $item in $items 
-where not(xs:string($item/@n) = $getty_cicos)
-return $item
+    for $item in $items 
+    where not(xs:string($item/@n) = $getty_cicos)
+    return $item
 
 return 
-<tei:list xmlns="http://www.tei-c.org/ns/1.0">
-{ for $i in $bads return $i }
-</tei:list>
+    <tei:list xmlns="http://www.tei-c.org/ns/1.0">
+        { for $i in $bads return $i }
+    </tei:list>
 

--- a/bin/forensics/missing_in_getty.rb
+++ b/bin/forensics/missing_in_getty.rb
@@ -6,7 +6,7 @@ require "set"
 require "csv"
 require "logger"
 
-basedir = "#{File.dirname(__FILE__)}/.."
+basedir = "#{File.dirname(__FILE__)}/../.."
 
 logger = Logger.new(STDOUT)
 

--- a/catalogo.tei.xml
+++ b/catalogo.tei.xml
@@ -5,7 +5,7 @@
          <fileDesc>
              <titleStmt>
                  <title>Catalogo ragionato dei libri d’arte d’antichità
-                     posseduti dal conte cicognara, tomo primo</title>
+                     posseduti dal conte cicognara</title>
                  <author>CONTE CICOGNARA</author>
              </titleStmt>
 	        <publicationStmt>


### PR DESCRIPTION
This PR adds a report, `catalogo_items_not_in_getty.xml`, that lists the _Catalogo_ items that do not have a corresponding record in the Getty dump. It also cleans up the code and corrects a small error in the _Catalogo_ encoding.
